### PR TITLE
feat: enable support for volcengine

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Adapter for web frameworks (Express, Koa) to run on serverless platforms across 
 | ---------------------- | ------------------------------- | ------------ | ------------ |
 | Alibaba Cloud (Aliyun) | Function Compute                | ✅ Supported | API Gateway  |
 | Tencent Cloud          | Serverless Cloud Function (SCF) | ✅ Supported | API Gateway  |
+| Volcengine             | veFaaS (函数服务)               | ✅ Supported | API Gateway  |
 
 ## Supported Frameworks
 
@@ -107,6 +108,22 @@ app.get('/api/users', (req, res) => {
 export const main_handler = serverlessAdapter(app, { provider: 'tencent' });
 ```
 
+#### Volcengine veFaaS Example
+
+```typescript
+import express from 'express';
+import serverlessAdapter from '@geek-fun/serverless-adapter';
+
+const app = express();
+
+app.get('/api/users', (req, res) => {
+  res.json({ users: [] });
+});
+
+// Handler for Volcengine veFaaS
+export const handler = serverlessAdapter(app, { provider: 'volcengine' });
+```
+
 ## API Reference
 
 ### `serverlessAdapter(app, options?)`
@@ -115,10 +132,10 @@ Creates a serverless handler for your Express or Koa application.
 
 #### Parameters
 
-| Parameter          | Type                    | Required | Description                                                  |
-| ------------------ | ----------------------- | -------- | ------------------------------------------------------------ |
-| `app`              | `Express \| Koa`        | Yes      | Express or Koa application instance                          |
-| `options.provider` | `'aliyun' \| 'tencent'` | No       | Explicitly specify cloud provider (auto-detected if omitted) |
+| Parameter          | Type                                    | Required | Description                                                  |
+| ------------------ | --------------------------------------- | -------- | ------------------------------------------------------------ |
+| `app`              | `Express \| Koa`                        | Yes      | Express or Koa application instance                          |
+| `options.provider` | `'aliyun' \| 'tencent' \| 'volcengine'` | No       | Explicitly specify cloud provider (auto-detected if omitted) |
 
 #### Returns
 
@@ -138,10 +155,11 @@ A function that handles serverless events:
 
 The adapter automatically detects the cloud provider by examining the `context` object:
 
-| Provider | Detection Fields                                         |
-| -------- | -------------------------------------------------------- |
-| Aliyun   | `accountId`, `credentials`, `service`, `tracing`         |
-| Tencent  | `tencentcloud_region`, `tencentcloud_appid`, `namespace` |
+| Provider   | Detection Fields                                         |
+| ---------- | -------------------------------------------------------- |
+| Aliyun     | `service.name`, `tracing`, `logger`, `function.memory`   |
+| Tencent    | `tencentcloud_region`, `tencentcloud_appid`, `namespace` |
+| Volcengine | `requestId`, `region`, `function.memoryMb`               |
 
 ## License
 

--- a/src/providers/aliyun.ts
+++ b/src/providers/aliyun.ts
@@ -35,6 +35,15 @@ export class AliyunProvider extends BaseProvider {
 
   detect(_rawEvent: ProviderEvent, rawContext: ProviderContext): boolean {
     const context = rawContext as AliyunApiGatewayContext;
-    return !!(context.accountId || context.credentials || context.service || context.tracing);
+
+    if (context.service?.name || context.tracing || context.logger) {
+      return true;
+    }
+
+    if (context.credentials && context.function?.memory !== undefined) {
+      return true;
+    }
+
+    return false;
   }
 }

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,6 +1,7 @@
 import { ServerlessProvider } from './base';
 import { AliyunProvider } from './aliyun';
 import { TencentProvider } from './tencent';
+import { VolcengineProvider } from './volcengine';
 import { CloudProvider, ProviderContext, ProviderEvent } from '../types';
 
 const providers: Map<CloudProvider, ServerlessProvider> = new Map();
@@ -31,7 +32,9 @@ export function getAllProviders(): Map<CloudProvider, ServerlessProvider> {
 
 registerProvider(new AliyunProvider());
 registerProvider(new TencentProvider());
+registerProvider(new VolcengineProvider());
 
 export { ServerlessProvider } from './base';
 export { AliyunProvider } from './aliyun';
 export { TencentProvider } from './tencent';
+export { VolcengineProvider } from './volcengine';

--- a/src/providers/volcengine.ts
+++ b/src/providers/volcengine.ts
@@ -1,0 +1,62 @@
+import { BaseProvider } from './base';
+import {
+  VolcengineApiGatewayEvent,
+  VolcengineVefaasContext,
+  VolcengineVefaasResponse,
+  ServerlessEvent,
+  ServerlessResponse,
+  ProviderContext,
+  ProviderEvent,
+} from '../types';
+
+export class VolcengineProvider extends BaseProvider {
+  readonly name = 'volcengine' as const;
+
+  normalizeEvent(rawEvent: ProviderEvent): ServerlessEvent {
+    const volcengineEvent = JSON.parse(
+      Buffer.from(rawEvent as Buffer).toString(),
+    ) as VolcengineApiGatewayEvent;
+
+    return {
+      path: volcengineEvent.path,
+      httpMethod: volcengineEvent.method,
+      headers: volcengineEvent.headers || {},
+      queryParameters: volcengineEvent.query || {},
+      pathParameters: {},
+      body: volcengineEvent.body,
+      isBase64Encoded: false,
+    };
+  }
+
+  formatResponse(response: ServerlessResponse): VolcengineVefaasResponse {
+    return {
+      statusCode: response.statusCode,
+      headers: response.headers,
+      body: response.body,
+    };
+  }
+
+  detect(_rawEvent: ProviderEvent, rawContext: ProviderContext): boolean {
+    const context = rawContext as VolcengineVefaasContext;
+    const aliyunContext = rawContext as {
+      service?: { name?: string };
+      tracing?: unknown;
+      logger?: unknown;
+    };
+    const hasAliyunSpecificFields = !!(
+      aliyunContext.service?.name ||
+      aliyunContext.tracing ||
+      aliyunContext.logger
+    );
+
+    if (hasAliyunSpecificFields) {
+      return false;
+    }
+
+    return !!(
+      context.requestId &&
+      context.region &&
+      (context.accountId || context.credentials || context.function?.memoryMb)
+    );
+  }
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -9,6 +9,13 @@ import {
   TencentEvent,
   TencentHandler,
 } from './tencent';
+import {
+  VolcengineApiGatewayEvent,
+  VolcengineVefaasContext,
+  VolcengineVefaasResponse,
+  VolcengineEvent,
+  VolcengineHandler,
+} from './volcengine';
 
 export { AliyunApiGatewayContext, AliyunEvent, AliyunResponse };
 export {
@@ -17,6 +24,13 @@ export {
   TencentScfResponse,
   TencentEvent,
   TencentHandler,
+};
+export {
+  VolcengineApiGatewayEvent,
+  VolcengineVefaasContext,
+  VolcengineVefaasResponse,
+  VolcengineEvent,
+  VolcengineHandler,
 };
 
 export type Context = AliyunApiGatewayContext;
@@ -48,17 +62,17 @@ export type ServerlessResponse = {
 /**
  * Supported cloud providers
  */
-export type CloudProvider = 'aliyun' | 'tencent';
+export type CloudProvider = 'aliyun' | 'tencent' | 'volcengine';
 
 /**
  * Provider-specific context types
  */
-export type ProviderContext = AliyunApiGatewayContext | TencentScfContext;
+export type ProviderContext = AliyunApiGatewayContext | TencentScfContext | VolcengineVefaasContext;
 
 /**
  * Provider-specific event types
  */
-export type ProviderEvent = AliyunEvent | TencentEvent;
+export type ProviderEvent = AliyunEvent | TencentEvent | VolcengineEvent;
 
 export type ServerlessAdapter = (app: Express | Application) => (
   event: Event,

--- a/src/types/volcengine.ts
+++ b/src/types/volcengine.ts
@@ -1,0 +1,68 @@
+import { IncomingHttpHeaders } from 'http';
+
+/**
+ * Volcengine veFaaS API Gateway Trigger Event
+ * @see https://www.volcengine.com/docs/6662/116904
+ */
+export interface VolcengineApiGatewayEvent {
+  path: string;
+  method: string;
+  headers: Record<string, string>;
+  query: Record<string, string>;
+  body: string;
+  requestContext: {
+    requestId: string;
+    stage: string;
+    serviceId: string;
+    sourceIp?: string;
+  };
+}
+
+/**
+ * Volcengine veFaaS Context Object
+ * @see https://www.volcengine.com/docs/6662/116908
+ */
+export interface VolcengineVefaasContext {
+  requestId: string;
+  credentials?: {
+    accessKeyId: string;
+    accessKeySecret: string;
+    securityToken: string;
+  };
+  function?: {
+    name: string;
+    handler: string;
+    memoryMb: number;
+    timeout: number;
+  };
+  service?: {
+    logProject: string;
+    logStore: string;
+    qualifier: string;
+    versionId: string;
+  };
+  region: string;
+  accountId: string;
+}
+
+/**
+ * Volcengine veFaaS Response for API Gateway Integration
+ */
+export interface VolcengineVefaasResponse {
+  statusCode: number;
+  headers: IncomingHttpHeaders;
+  body: string;
+}
+
+/**
+ * Volcengine veFaaS Event (Buffer containing JSON)
+ */
+export type VolcengineEvent = Buffer;
+
+/**
+ * Volcengine veFaaS Handler Type
+ */
+export type VolcengineHandler = (
+  event: VolcengineEvent,
+  context: VolcengineVefaasContext,
+) => Promise<VolcengineVefaasResponse>;

--- a/tests/fixtures/tencentContext.ts
+++ b/tests/fixtures/tencentContext.ts
@@ -19,7 +19,7 @@ export const defaultTencentContext: TencentScfContext = {
 export const defaultTencentApiGatewayEvent: TencentApiGatewayEvent = {
   requestContext: {
     serviceId: 'service-test-id',
-    path: '/test',
+    path: '/api/test',
     httpMethod: 'GET',
     requestId: 'req-12345',
     identity: {
@@ -28,7 +28,7 @@ export const defaultTencentApiGatewayEvent: TencentApiGatewayEvent = {
     sourceIp: '192.168.1.1',
     stage: 'release',
   },
-  path: '/test',
+  path: '/api/test',
   httpMethod: 'GET',
   queryString: {},
   body: '',

--- a/tests/fixtures/volcengineContext.ts
+++ b/tests/fixtures/volcengineContext.ts
@@ -1,0 +1,53 @@
+import { VolcengineVefaasContext, VolcengineApiGatewayEvent } from '../../src/types/volcengine';
+
+export const defaultVolcengineContext: VolcengineVefaasContext = {
+  requestId: 'volcengine-request-id-12345',
+  credentials: {
+    accessKeyId: 'test-access-key-id',
+    accessKeySecret: 'test-access-key-secret',
+    securityToken: 'test-security-token',
+  },
+  function: {
+    name: 'test-function',
+    handler: 'index.handler',
+    memoryMb: 128,
+    timeout: 30,
+  },
+  service: {
+    logProject: 'test-log-project',
+    logStore: 'test-log-store',
+    qualifier: '$LATEST',
+    versionId: 'v1',
+  },
+  region: 'cn-beijing',
+  accountId: '1234567890',
+};
+
+export const defaultVolcengineApiGatewayEvent: VolcengineApiGatewayEvent = {
+  path: '/api/test',
+  method: 'GET',
+  headers: {
+    'Content-Type': 'application/json',
+  },
+  query: {},
+  body: '',
+  requestContext: {
+    requestId: 'req-12345',
+    stage: 'release',
+    serviceId: 'service-test-id',
+  },
+};
+
+export const createVolcengineEvent = (
+  overrides: Partial<VolcengineApiGatewayEvent> = {},
+): VolcengineApiGatewayEvent => ({
+  ...defaultVolcengineApiGatewayEvent,
+  ...overrides,
+});
+
+export const createVolcengineContext = (
+  overrides: Partial<VolcengineVefaasContext> = {},
+): VolcengineVefaasContext => ({
+  ...defaultVolcengineContext,
+  ...overrides,
+});

--- a/tests/index-tencent-express-5x.spec.test.ts
+++ b/tests/index-tencent-express-5x.spec.test.ts
@@ -1,0 +1,142 @@
+import express, { Express, Request, Response } from 'express5';
+import { createTencentContext, createTencentEvent } from './fixtures/tencentContext';
+import { sendRequest } from './fixtures/requestHelper';
+
+describe('Tencent SCF with Express 5.x', () => {
+  let app: Express;
+
+  beforeEach(() => {
+    app = express();
+  });
+
+  it('basic middleware should set statusCode and default body', async () => {
+    app.use((req: Request, res: Response) => {
+      res.status(418).send(`I'm a teapot`);
+    });
+
+    const response = await sendRequest(
+      app,
+      createTencentEvent() as unknown as Record<string, unknown>,
+      createTencentContext() as unknown as Record<string, unknown>,
+    );
+    expect(response.statusCode).toEqual(418);
+    expect(response.body).toEqual(`I'm a teapot`);
+  });
+
+  it('express.json() should parse json body', async () => {
+    app.use(express.json());
+    app.use((req: Request, res: Response) => {
+      res.status(200).send(req.body.hello);
+    });
+
+    const response = await sendRequest(
+      app,
+      createTencentEvent({
+        httpMethod: 'POST',
+        body: JSON.stringify({ hello: 'world' }),
+        headers: { 'Content-Type': 'application/json' },
+      }) as unknown as Record<string, unknown>,
+      createTencentContext() as unknown as Record<string, unknown>,
+    );
+
+    expect(response.statusCode).toEqual(200);
+    expect(response.body).toEqual('world');
+  });
+
+  it('basic middleware should get query params', async () => {
+    app.use((req: Request, res: Response) => {
+      res.status(200).send(req.query.foo as string);
+    });
+
+    const response = await sendRequest(
+      app,
+      createTencentEvent({
+        httpMethod: 'GET',
+        queryStringParameters: { foo: 'bar' },
+      }) as unknown as Record<string, unknown>,
+      createTencentContext() as unknown as Record<string, unknown>,
+    );
+    expect(response.statusCode).toEqual(200);
+    expect(response.body).toEqual('bar');
+  });
+
+  it('should match verbs', async () => {
+    app.get('/api/test', (req: Request, res: Response) => {
+      res.status(200).send('foo');
+    });
+    app.put('/api/test', (req: Request, res: Response) => {
+      res.status(201).send('bar');
+    });
+
+    const response = await sendRequest(
+      app,
+      createTencentEvent({ httpMethod: 'PUT' }) as unknown as Record<string, unknown>,
+      createTencentContext() as unknown as Record<string, unknown>,
+    );
+
+    expect(response.statusCode).toEqual(201);
+    expect(response.body).toEqual('bar');
+  });
+
+  it('should handle custom headers in response', async () => {
+    app.use((req: Request, res: Response) => {
+      res.setHeader('X-Custom-Header', 'custom-value');
+      res.status(200).send('ok');
+    });
+
+    const response = await sendRequest(
+      app,
+      createTencentEvent() as unknown as Record<string, unknown>,
+      createTencentContext() as unknown as Record<string, unknown>,
+    );
+
+    expect(response.statusCode).toEqual(200);
+    expect(response.headers['x-custom-header']).toEqual('custom-value');
+  });
+
+  it('should handle response with JSON', async () => {
+    app.use((req: Request, res: Response) => {
+      res.status(200).json({ message: 'hello', count: 42 });
+    });
+
+    const response = await sendRequest(
+      app,
+      createTencentEvent() as unknown as Record<string, unknown>,
+      createTencentContext() as unknown as Record<string, unknown>,
+    );
+
+    expect(response.statusCode).toEqual(200);
+    expect(JSON.parse(response.body)).toEqual({ message: 'hello', count: 42 });
+  });
+
+  it('should handle 500 error from middleware', async () => {
+    app.use(() => {
+      throw new Error('Internal server error');
+    });
+
+    const response = await sendRequest(
+      app,
+      createTencentEvent() as unknown as Record<string, unknown>,
+      createTencentContext() as unknown as Record<string, unknown>,
+    );
+
+    expect(response.statusCode).toEqual(500);
+  });
+
+  it('should handle 404 response', async () => {
+    app.get('/api/exists', (req: Request, res: Response) => {
+      res.status(200).send('exists');
+    });
+
+    const response = await sendRequest(
+      app,
+      createTencentEvent({
+        httpMethod: 'GET',
+        path: '/api/notexists',
+      }) as unknown as Record<string, unknown>,
+      createTencentContext() as unknown as Record<string, unknown>,
+    );
+
+    expect(response.statusCode).toEqual(404);
+  });
+});

--- a/tests/index-tencent-koa-2x.spec.test.ts
+++ b/tests/index-tencent-koa-2x.spec.test.ts
@@ -1,0 +1,162 @@
+import Koa from 'koa2';
+import Router from '@koa/router';
+import koaBody from 'koa-body';
+import { createTencentContext, createTencentEvent } from './fixtures/tencentContext';
+import { sendRequest } from './fixtures/requestHelper';
+
+describe('Tencent SCF with Koa 2.x', () => {
+  let app: Koa;
+  let router: Router;
+
+  beforeEach(() => {
+    app = new Koa();
+    app.use(koaBody({ text: true, json: true, multipart: true, urlencoded: true }));
+    router = new Router();
+  });
+
+  it('basic middleware should set statusCode and default body', async () => {
+    router.get('/api/test', (ctx) => {
+      ctx.status = 418;
+      ctx.body = 'Hello, Tencent SCF!';
+    });
+    app.use(router.routes());
+
+    const response = await sendRequest(
+      app,
+      createTencentEvent() as unknown as Record<string, unknown>,
+      createTencentContext() as unknown as Record<string, unknown>,
+    );
+
+    expect(response.statusCode).toEqual(418);
+    expect(response.body).toEqual('Hello, Tencent SCF!');
+  });
+
+  it('basic middleware should parse json body', async () => {
+    router.post('/api/test', (ctx) => {
+      ctx.status = 200;
+      ctx.body = ctx.request.body.hello;
+    });
+    app.use(router.routes());
+
+    const response = await sendRequest(
+      app,
+      createTencentEvent({
+        httpMethod: 'POST',
+        body: JSON.stringify({ hello: 'world' }),
+        headers: { 'Content-Type': 'application/json' },
+      }) as unknown as Record<string, unknown>,
+      createTencentContext() as unknown as Record<string, unknown>,
+    );
+
+    expect(response.statusCode).toEqual(200);
+    expect(response.body).toEqual('world');
+  });
+
+  it('basic middleware should get query params', async () => {
+    router.get('/api/test', (ctx) => {
+      ctx.status = 200;
+      ctx.body = ctx.request.query.foo;
+    });
+    app.use(router.routes());
+
+    const response = await sendRequest(
+      app,
+      createTencentEvent({
+        httpMethod: 'GET',
+        queryStringParameters: { foo: 'bar' },
+      }) as unknown as Record<string, unknown>,
+      createTencentContext() as unknown as Record<string, unknown>,
+    );
+    expect(response.statusCode).toEqual(200);
+    expect(response.body).toEqual('bar');
+  });
+
+  it('should match verbs', async () => {
+    router.get('/api/test', (ctx) => {
+      ctx.status = 200;
+      ctx.body = 'foo';
+    });
+    router.put('/api/test', (ctx) => {
+      ctx.status = 201;
+      ctx.body = 'bar';
+    });
+    app.use(router.routes());
+
+    const response = await sendRequest(
+      app,
+      createTencentEvent({ httpMethod: 'PUT' }) as unknown as Record<string, unknown>,
+      createTencentContext() as unknown as Record<string, unknown>,
+    );
+
+    expect(response.statusCode).toEqual(201);
+    expect(response.body).toEqual('bar');
+  });
+
+  it('should handle custom headers in response', async () => {
+    router.get('/api/test', (ctx) => {
+      ctx.set('X-Custom-Header', 'custom-value');
+      ctx.status = 200;
+      ctx.body = 'ok';
+    });
+    app.use(router.routes());
+
+    const response = await sendRequest(
+      app,
+      createTencentEvent() as unknown as Record<string, unknown>,
+      createTencentContext() as unknown as Record<string, unknown>,
+    );
+
+    expect(response.statusCode).toEqual(200);
+    expect(response.headers['x-custom-header']).toEqual('custom-value');
+  });
+
+  it('should handle response with JSON', async () => {
+    router.get('/api/test', (ctx) => {
+      ctx.status = 200;
+      ctx.body = { message: 'hello', count: 42 };
+    });
+    app.use(router.routes());
+
+    const response = await sendRequest(
+      app,
+      createTencentEvent() as unknown as Record<string, unknown>,
+      createTencentContext() as unknown as Record<string, unknown>,
+    );
+
+    expect(response.statusCode).toEqual(200);
+    expect(JSON.parse(response.body)).toEqual({ message: 'hello', count: 42 });
+  });
+
+  it('should handle error from middleware', async () => {
+    app.use(() => {
+      throw new Error('Koa error');
+    });
+
+    const response = await sendRequest(
+      app,
+      createTencentEvent() as unknown as Record<string, unknown>,
+      createTencentContext() as unknown as Record<string, unknown>,
+    );
+
+    expect(response.statusCode).toEqual(500);
+  });
+
+  it('should handle 404 response', async () => {
+    router.get('/api/exists', (ctx) => {
+      ctx.status = 200;
+      ctx.body = 'exists';
+    });
+    app.use(router.routes());
+
+    const response = await sendRequest(
+      app,
+      createTencentEvent({
+        httpMethod: 'GET',
+        path: '/api/notexists',
+      }) as unknown as Record<string, unknown>,
+      createTencentContext() as unknown as Record<string, unknown>,
+    );
+
+    expect(response.statusCode).toEqual(404);
+  });
+});

--- a/tests/index-tencent-koa-3x.spec.test.ts
+++ b/tests/index-tencent-koa-3x.spec.test.ts
@@ -1,0 +1,162 @@
+import Koa from 'koa3';
+import Router from '@koa/router';
+import koaBody from 'koa-body';
+import { createTencentContext, createTencentEvent } from './fixtures/tencentContext';
+import { sendRequest } from './fixtures/requestHelper';
+
+describe('Tencent SCF with Koa 3.x', () => {
+  let app: Koa;
+  let router: Router;
+
+  beforeEach(() => {
+    app = new Koa();
+    app.use(koaBody({ text: true, json: true, multipart: true, urlencoded: true }));
+    router = new Router();
+  });
+
+  it('basic middleware should set statusCode and default body', async () => {
+    router.get('/api/test', (ctx) => {
+      ctx.status = 418;
+      ctx.body = 'Hello, Tencent SCF!';
+    });
+    app.use(router.routes());
+
+    const response = await sendRequest(
+      app,
+      createTencentEvent() as unknown as Record<string, unknown>,
+      createTencentContext() as unknown as Record<string, unknown>,
+    );
+
+    expect(response.statusCode).toEqual(418);
+    expect(response.body).toEqual('Hello, Tencent SCF!');
+  });
+
+  it('basic middleware should parse json body', async () => {
+    router.post('/api/test', (ctx) => {
+      ctx.status = 200;
+      ctx.body = ctx.request.body.hello;
+    });
+    app.use(router.routes());
+
+    const response = await sendRequest(
+      app,
+      createTencentEvent({
+        httpMethod: 'POST',
+        body: JSON.stringify({ hello: 'world' }),
+        headers: { 'Content-Type': 'application/json' },
+      }) as unknown as Record<string, unknown>,
+      createTencentContext() as unknown as Record<string, unknown>,
+    );
+
+    expect(response.statusCode).toEqual(200);
+    expect(response.body).toEqual('world');
+  });
+
+  it('basic middleware should get query params', async () => {
+    router.get('/api/test', (ctx) => {
+      ctx.status = 200;
+      ctx.body = ctx.request.query.foo;
+    });
+    app.use(router.routes());
+
+    const response = await sendRequest(
+      app,
+      createTencentEvent({
+        httpMethod: 'GET',
+        queryStringParameters: { foo: 'bar' },
+      }) as unknown as Record<string, unknown>,
+      createTencentContext() as unknown as Record<string, unknown>,
+    );
+    expect(response.statusCode).toEqual(200);
+    expect(response.body).toEqual('bar');
+  });
+
+  it('should match verbs', async () => {
+    router.get('/api/test', (ctx) => {
+      ctx.status = 200;
+      ctx.body = 'foo';
+    });
+    router.put('/api/test', (ctx) => {
+      ctx.status = 201;
+      ctx.body = 'bar';
+    });
+    app.use(router.routes());
+
+    const response = await sendRequest(
+      app,
+      createTencentEvent({ httpMethod: 'PUT' }) as unknown as Record<string, unknown>,
+      createTencentContext() as unknown as Record<string, unknown>,
+    );
+
+    expect(response.statusCode).toEqual(201);
+    expect(response.body).toEqual('bar');
+  });
+
+  it('should handle custom headers in response', async () => {
+    router.get('/api/test', (ctx) => {
+      ctx.set('X-Custom-Header', 'custom-value');
+      ctx.status = 200;
+      ctx.body = 'ok';
+    });
+    app.use(router.routes());
+
+    const response = await sendRequest(
+      app,
+      createTencentEvent() as unknown as Record<string, unknown>,
+      createTencentContext() as unknown as Record<string, unknown>,
+    );
+
+    expect(response.statusCode).toEqual(200);
+    expect(response.headers['x-custom-header']).toEqual('custom-value');
+  });
+
+  it('should handle response with JSON', async () => {
+    router.get('/api/test', (ctx) => {
+      ctx.status = 200;
+      ctx.body = { message: 'hello', count: 42 };
+    });
+    app.use(router.routes());
+
+    const response = await sendRequest(
+      app,
+      createTencentEvent() as unknown as Record<string, unknown>,
+      createTencentContext() as unknown as Record<string, unknown>,
+    );
+
+    expect(response.statusCode).toEqual(200);
+    expect(JSON.parse(response.body)).toEqual({ message: 'hello', count: 42 });
+  });
+
+  it('should handle error from middleware', async () => {
+    app.use(() => {
+      throw new Error('Koa error');
+    });
+
+    const response = await sendRequest(
+      app,
+      createTencentEvent() as unknown as Record<string, unknown>,
+      createTencentContext() as unknown as Record<string, unknown>,
+    );
+
+    expect(response.statusCode).toEqual(500);
+  });
+
+  it('should handle 404 response', async () => {
+    router.get('/api/exists', (ctx) => {
+      ctx.status = 200;
+      ctx.body = 'exists';
+    });
+    app.use(router.routes());
+
+    const response = await sendRequest(
+      app,
+      createTencentEvent({
+        httpMethod: 'GET',
+        path: '/api/notexists',
+      }) as unknown as Record<string, unknown>,
+      createTencentContext() as unknown as Record<string, unknown>,
+    );
+
+    expect(response.statusCode).toEqual(404);
+  });
+});

--- a/tests/index-tencent.spec.test.ts
+++ b/tests/index-tencent.spec.test.ts
@@ -1,0 +1,234 @@
+import express, { Express, Request, Response } from 'express4';
+import bodyParser from 'body-parser';
+import { createTencentContext, createTencentEvent } from './fixtures/tencentContext';
+import { sendRequest } from './fixtures/requestHelper';
+
+describe('Tencent SCF with Express 4.x', () => {
+  let app: Express;
+
+  beforeEach(() => {
+    app = express();
+  });
+
+  it('basic middleware should set statusCode and default body', async () => {
+    app.use((req: Request, res: Response) => {
+      res.status(418).send(`I'm a teapot`);
+    });
+
+    const response = await sendRequest(
+      app,
+      createTencentEvent() as unknown as Record<string, unknown>,
+      createTencentContext() as unknown as Record<string, unknown>,
+    );
+    expect(response.statusCode).toEqual(418);
+    expect(response.body).toEqual(`I'm a teapot`);
+  });
+
+  it('basic middleware should get json body', async () => {
+    app.use(bodyParser.json());
+    app.use((req: Request, res: Response) => {
+      res.status(200).send(req.body.hello);
+    });
+
+    const response = await sendRequest(
+      app,
+      createTencentEvent({
+        httpMethod: 'POST',
+        body: JSON.stringify({ hello: 'world' }),
+        headers: { 'Content-Type': 'application/json' },
+      }) as unknown as Record<string, unknown>,
+      createTencentContext() as unknown as Record<string, unknown>,
+    );
+
+    expect(response.statusCode).toEqual(200);
+    expect(response.body).toEqual('world');
+  });
+
+  it('basic middleware should get query params', async () => {
+    app.use((req: Request, res: Response) => {
+      res.status(200).send(req.query.foo as string);
+    });
+
+    const response = await sendRequest(
+      app,
+      createTencentEvent({
+        httpMethod: 'GET',
+        queryStringParameters: { foo: 'bar' },
+      }) as unknown as Record<string, unknown>,
+      createTencentContext() as unknown as Record<string, unknown>,
+    );
+    expect(response.statusCode).toEqual(200);
+    expect(response.body).toEqual('bar');
+  });
+
+  it('should match verbs', async () => {
+    app.get('/*', (req: Request, res: Response) => {
+      res.status(200).send('foo');
+    });
+    app.put('/*', (req: Request, res: Response) => {
+      res.status(201).send('bar');
+    });
+
+    const response = await sendRequest(
+      app,
+      createTencentEvent({ httpMethod: 'PUT' }) as unknown as Record<string, unknown>,
+      createTencentContext() as unknown as Record<string, unknown>,
+    );
+
+    expect(response.statusCode).toEqual(201);
+    expect(response.body).toEqual('bar');
+  });
+
+  it('should handle DELETE method', async () => {
+    app.delete('/*', (req: Request, res: Response) => {
+      res.status(204).send('deleted');
+    });
+
+    const response = await sendRequest(
+      app,
+      createTencentEvent({ httpMethod: 'DELETE' }) as unknown as Record<string, unknown>,
+      createTencentContext() as unknown as Record<string, unknown>,
+    );
+    expect(response.statusCode).toEqual(204);
+  });
+
+  it('should handle PATCH method', async () => {
+    app.patch('/*', (req: Request, res: Response) => {
+      res.status(200).send('patched');
+    });
+
+    const response = await sendRequest(
+      app,
+      createTencentEvent({
+        httpMethod: 'PATCH',
+        body: JSON.stringify({ update: 'value' }),
+        headers: { 'Content-Type': 'application/json' },
+      }) as unknown as Record<string, unknown>,
+      createTencentContext() as unknown as Record<string, unknown>,
+    );
+    expect(response.statusCode).toEqual(200);
+    expect(response.body).toEqual('patched');
+  });
+
+  it('should handle custom headers in response', async () => {
+    app.use((req: Request, res: Response) => {
+      res.setHeader('X-Custom-Header', 'custom-value');
+      res.setHeader('X-Another', 'another-value');
+      res.status(200).send('ok');
+    });
+
+    const response = await sendRequest(
+      app,
+      createTencentEvent() as unknown as Record<string, unknown>,
+      createTencentContext() as unknown as Record<string, unknown>,
+    );
+
+    expect(response.statusCode).toEqual(200);
+    expect(response.headers['x-custom-header']).toEqual('custom-value');
+    expect(response.headers['x-another']).toEqual('another-value');
+  });
+
+  it('should handle response with JSON', async () => {
+    app.use((req: Request, res: Response) => {
+      res.status(200).json({ message: 'hello', count: 42 });
+    });
+
+    const response = await sendRequest(
+      app,
+      createTencentEvent() as unknown as Record<string, unknown>,
+      createTencentContext() as unknown as Record<string, unknown>,
+    );
+
+    expect(response.statusCode).toEqual(200);
+    expect(JSON.parse(response.body)).toEqual({ message: 'hello', count: 42 });
+  });
+
+  it('should handle empty response body', async () => {
+    app.use((req: Request, res: Response) => {
+      res.status(204).end();
+    });
+
+    const response = await sendRequest(
+      app,
+      createTencentEvent() as unknown as Record<string, unknown>,
+      createTencentContext() as unknown as Record<string, unknown>,
+    );
+
+    expect(response.statusCode).toEqual(204);
+    expect(response.body).toEqual('');
+  });
+
+  it('should handle 500 error from middleware', async () => {
+    app.use(() => {
+      throw new Error('Internal server error');
+    });
+
+    const response = await sendRequest(
+      app,
+      createTencentEvent() as unknown as Record<string, unknown>,
+      createTencentContext() as unknown as Record<string, unknown>,
+    );
+
+    expect(response.statusCode).toEqual(500);
+  });
+
+  it('should handle request with multiple query parameters', async () => {
+    app.use((req: Request, res: Response) => {
+      res.status(200).json(req.query);
+    });
+
+    const response = await sendRequest(
+      app,
+      createTencentEvent({
+        httpMethod: 'GET',
+        queryStringParameters: {
+          foo: 'bar',
+          baz: 'qux',
+          num: '123',
+        },
+      }) as unknown as Record<string, unknown>,
+      createTencentContext() as unknown as Record<string, unknown>,
+    );
+
+    expect(response.statusCode).toEqual(200);
+    expect(JSON.parse(response.body)).toEqual({
+      foo: 'bar',
+      baz: 'qux',
+      num: '123',
+    });
+  });
+
+  it('should handle 404 response', async () => {
+    app.get('/api/exists', (req: Request, res: Response) => {
+      res.status(200).send('exists');
+    });
+
+    const response = await sendRequest(
+      app,
+      createTencentEvent({
+        httpMethod: 'GET',
+        path: '/api/notexists',
+      }) as unknown as Record<string, unknown>,
+      createTencentContext() as unknown as Record<string, unknown>,
+    );
+
+    expect(response.statusCode).toEqual(404);
+  });
+
+  it('should return Tencent SCF response format', async () => {
+    app.use((req: Request, res: Response) => {
+      res.status(200).json({ provider: 'tencent' });
+    });
+
+    const response = await sendRequest(
+      app,
+      createTencentEvent() as unknown as Record<string, unknown>,
+      createTencentContext() as unknown as Record<string, unknown>,
+    );
+
+    expect(response).toHaveProperty('statusCode');
+    expect(response).toHaveProperty('body');
+    expect(response).toHaveProperty('headers');
+    expect(response).toHaveProperty('isBase64Encoded');
+  });
+});

--- a/tests/index-volcengine-express-5x.spec.test.ts
+++ b/tests/index-volcengine-express-5x.spec.test.ts
@@ -1,0 +1,142 @@
+import express, { Express, Request, Response } from 'express5';
+import { createVolcengineContext, createVolcengineEvent } from './fixtures/volcengineContext';
+import { sendRequest } from './fixtures/requestHelper';
+
+describe('Volcengine veFaaS with Express 5.x', () => {
+  let app: Express;
+
+  beforeEach(() => {
+    app = express();
+  });
+
+  it('basic middleware should set statusCode and default body', async () => {
+    app.use((req: Request, res: Response) => {
+      res.status(418).send(`I'm a teapot`);
+    });
+
+    const response = await sendRequest(
+      app,
+      createVolcengineEvent() as unknown as Record<string, unknown>,
+      createVolcengineContext() as unknown as Record<string, unknown>,
+    );
+    expect(response.statusCode).toEqual(418);
+    expect(response.body).toEqual(`I'm a teapot`);
+  });
+
+  it('express.json() should parse json body', async () => {
+    app.use(express.json());
+    app.use((req: Request, res: Response) => {
+      res.status(200).send(req.body.hello);
+    });
+
+    const response = await sendRequest(
+      app,
+      createVolcengineEvent({
+        method: 'POST',
+        body: JSON.stringify({ hello: 'world' }),
+        headers: { 'Content-Type': 'application/json' },
+      }) as unknown as Record<string, unknown>,
+      createVolcengineContext() as unknown as Record<string, unknown>,
+    );
+
+    expect(response.statusCode).toEqual(200);
+    expect(response.body).toEqual('world');
+  });
+
+  it('basic middleware should get query params', async () => {
+    app.use((req: Request, res: Response) => {
+      res.status(200).send(req.query.foo as string);
+    });
+
+    const response = await sendRequest(
+      app,
+      createVolcengineEvent({
+        method: 'GET',
+        query: { foo: 'bar' },
+      }) as unknown as Record<string, unknown>,
+      createVolcengineContext() as unknown as Record<string, unknown>,
+    );
+    expect(response.statusCode).toEqual(200);
+    expect(response.body).toEqual('bar');
+  });
+
+  it('should match verbs', async () => {
+    app.get('/api/test', (req: Request, res: Response) => {
+      res.status(200).send('foo');
+    });
+    app.put('/api/test', (req: Request, res: Response) => {
+      res.status(201).send('bar');
+    });
+
+    const response = await sendRequest(
+      app,
+      createVolcengineEvent({ method: 'PUT' }) as unknown as Record<string, unknown>,
+      createVolcengineContext() as unknown as Record<string, unknown>,
+    );
+
+    expect(response.statusCode).toEqual(201);
+    expect(response.body).toEqual('bar');
+  });
+
+  it('should handle custom headers in response', async () => {
+    app.use((req: Request, res: Response) => {
+      res.setHeader('X-Custom-Header', 'custom-value');
+      res.status(200).send('ok');
+    });
+
+    const response = await sendRequest(
+      app,
+      createVolcengineEvent() as unknown as Record<string, unknown>,
+      createVolcengineContext() as unknown as Record<string, unknown>,
+    );
+
+    expect(response.statusCode).toEqual(200);
+    expect(response.headers['x-custom-header']).toEqual('custom-value');
+  });
+
+  it('should handle response with JSON', async () => {
+    app.use((req: Request, res: Response) => {
+      res.status(200).json({ message: 'hello', count: 42 });
+    });
+
+    const response = await sendRequest(
+      app,
+      createVolcengineEvent() as unknown as Record<string, unknown>,
+      createVolcengineContext() as unknown as Record<string, unknown>,
+    );
+
+    expect(response.statusCode).toEqual(200);
+    expect(JSON.parse(response.body)).toEqual({ message: 'hello', count: 42 });
+  });
+
+  it('should handle 500 error from middleware', async () => {
+    app.use(() => {
+      throw new Error('Internal server error');
+    });
+
+    const response = await sendRequest(
+      app,
+      createVolcengineEvent() as unknown as Record<string, unknown>,
+      createVolcengineContext() as unknown as Record<string, unknown>,
+    );
+
+    expect(response.statusCode).toEqual(500);
+  });
+
+  it('should handle 404 response', async () => {
+    app.get('/api/exists', (req: Request, res: Response) => {
+      res.status(200).send('exists');
+    });
+
+    const response = await sendRequest(
+      app,
+      createVolcengineEvent({
+        method: 'GET',
+        path: '/api/notexists',
+      }) as unknown as Record<string, unknown>,
+      createVolcengineContext() as unknown as Record<string, unknown>,
+    );
+
+    expect(response.statusCode).toEqual(404);
+  });
+});

--- a/tests/index-volcengine-koa-2x.spec.test.ts
+++ b/tests/index-volcengine-koa-2x.spec.test.ts
@@ -1,0 +1,162 @@
+import Koa from 'koa2';
+import Router from '@koa/router';
+import koaBody from 'koa-body';
+import { createVolcengineContext, createVolcengineEvent } from './fixtures/volcengineContext';
+import { sendRequest } from './fixtures/requestHelper';
+
+describe('Volcengine veFaaS with Koa 2.x', () => {
+  let app: Koa;
+  let router: Router;
+
+  beforeEach(() => {
+    app = new Koa();
+    app.use(koaBody({ text: true, json: true, multipart: true, urlencoded: true }));
+    router = new Router();
+  });
+
+  it('basic middleware should set statusCode and default body', async () => {
+    router.get('/api/test', (ctx) => {
+      ctx.status = 418;
+      ctx.body = 'Hello, Volcengine veFaaS!';
+    });
+    app.use(router.routes());
+
+    const response = await sendRequest(
+      app,
+      createVolcengineEvent() as unknown as Record<string, unknown>,
+      createVolcengineContext() as unknown as Record<string, unknown>,
+    );
+
+    expect(response.statusCode).toEqual(418);
+    expect(response.body).toEqual('Hello, Volcengine veFaaS!');
+  });
+
+  it('basic middleware should parse json body', async () => {
+    router.post('/api/test', (ctx) => {
+      ctx.status = 200;
+      ctx.body = ctx.request.body.hello;
+    });
+    app.use(router.routes());
+
+    const response = await sendRequest(
+      app,
+      createVolcengineEvent({
+        method: 'POST',
+        body: JSON.stringify({ hello: 'world' }),
+        headers: { 'Content-Type': 'application/json' },
+      }) as unknown as Record<string, unknown>,
+      createVolcengineContext() as unknown as Record<string, unknown>,
+    );
+
+    expect(response.statusCode).toEqual(200);
+    expect(response.body).toEqual('world');
+  });
+
+  it('basic middleware should get query params', async () => {
+    router.get('/api/test', (ctx) => {
+      ctx.status = 200;
+      ctx.body = ctx.request.query.foo;
+    });
+    app.use(router.routes());
+
+    const response = await sendRequest(
+      app,
+      createVolcengineEvent({
+        method: 'GET',
+        query: { foo: 'bar' },
+      }) as unknown as Record<string, unknown>,
+      createVolcengineContext() as unknown as Record<string, unknown>,
+    );
+    expect(response.statusCode).toEqual(200);
+    expect(response.body).toEqual('bar');
+  });
+
+  it('should match verbs', async () => {
+    router.get('/api/test', (ctx) => {
+      ctx.status = 200;
+      ctx.body = 'foo';
+    });
+    router.put('/api/test', (ctx) => {
+      ctx.status = 201;
+      ctx.body = 'bar';
+    });
+    app.use(router.routes());
+
+    const response = await sendRequest(
+      app,
+      createVolcengineEvent({ method: 'PUT' }) as unknown as Record<string, unknown>,
+      createVolcengineContext() as unknown as Record<string, unknown>,
+    );
+
+    expect(response.statusCode).toEqual(201);
+    expect(response.body).toEqual('bar');
+  });
+
+  it('should handle custom headers in response', async () => {
+    router.get('/api/test', (ctx) => {
+      ctx.set('X-Custom-Header', 'custom-value');
+      ctx.status = 200;
+      ctx.body = 'ok';
+    });
+    app.use(router.routes());
+
+    const response = await sendRequest(
+      app,
+      createVolcengineEvent() as unknown as Record<string, unknown>,
+      createVolcengineContext() as unknown as Record<string, unknown>,
+    );
+
+    expect(response.statusCode).toEqual(200);
+    expect(response.headers['x-custom-header']).toEqual('custom-value');
+  });
+
+  it('should handle response with JSON', async () => {
+    router.get('/api/test', (ctx) => {
+      ctx.status = 200;
+      ctx.body = { message: 'hello', count: 42 };
+    });
+    app.use(router.routes());
+
+    const response = await sendRequest(
+      app,
+      createVolcengineEvent() as unknown as Record<string, unknown>,
+      createVolcengineContext() as unknown as Record<string, unknown>,
+    );
+
+    expect(response.statusCode).toEqual(200);
+    expect(JSON.parse(response.body)).toEqual({ message: 'hello', count: 42 });
+  });
+
+  it('should handle error from middleware', async () => {
+    app.use(() => {
+      throw new Error('Koa error');
+    });
+
+    const response = await sendRequest(
+      app,
+      createVolcengineEvent() as unknown as Record<string, unknown>,
+      createVolcengineContext() as unknown as Record<string, unknown>,
+    );
+
+    expect(response.statusCode).toEqual(500);
+  });
+
+  it('should handle 404 response', async () => {
+    router.get('/api/exists', (ctx) => {
+      ctx.status = 200;
+      ctx.body = 'exists';
+    });
+    app.use(router.routes());
+
+    const response = await sendRequest(
+      app,
+      createVolcengineEvent({
+        method: 'GET',
+        path: '/api/notexists',
+      }) as unknown as Record<string, unknown>,
+      createVolcengineContext() as unknown as Record<string, unknown>,
+    );
+
+    expect(response.statusCode).toEqual(404);
+  });
+});

--- a/tests/index-volcengine-koa-3x.spec.test.ts
+++ b/tests/index-volcengine-koa-3x.spec.test.ts
@@ -1,0 +1,162 @@
+import Koa from 'koa3';
+import Router from '@koa/router';
+import koaBody from 'koa-body';
+import { createVolcengineContext, createVolcengineEvent } from './fixtures/volcengineContext';
+import { sendRequest } from './fixtures/requestHelper';
+
+describe('Volcengine veFaaS with Koa 3.x', () => {
+  let app: Koa;
+  let router: Router;
+
+  beforeEach(() => {
+    app = new Koa();
+    app.use(koaBody({ text: true, json: true, multipart: true, urlencoded: true }));
+    router = new Router();
+  });
+
+  it('basic middleware should set statusCode and default body', async () => {
+    router.get('/api/test', (ctx) => {
+      ctx.status = 418;
+      ctx.body = 'Hello, Volcengine veFaaS!';
+    });
+    app.use(router.routes());
+
+    const response = await sendRequest(
+      app,
+      createVolcengineEvent() as unknown as Record<string, unknown>,
+      createVolcengineContext() as unknown as Record<string, unknown>,
+    );
+
+    expect(response.statusCode).toEqual(418);
+    expect(response.body).toEqual('Hello, Volcengine veFaaS!');
+  });
+
+  it('basic middleware should parse json body', async () => {
+    router.post('/api/test', (ctx) => {
+      ctx.status = 200;
+      ctx.body = ctx.request.body.hello;
+    });
+    app.use(router.routes());
+
+    const response = await sendRequest(
+      app,
+      createVolcengineEvent({
+        method: 'POST',
+        body: JSON.stringify({ hello: 'world' }),
+        headers: { 'Content-Type': 'application/json' },
+      }) as unknown as Record<string, unknown>,
+      createVolcengineContext() as unknown as Record<string, unknown>,
+    );
+
+    expect(response.statusCode).toEqual(200);
+    expect(response.body).toEqual('world');
+  });
+
+  it('basic middleware should get query params', async () => {
+    router.get('/api/test', (ctx) => {
+      ctx.status = 200;
+      ctx.body = ctx.request.query.foo;
+    });
+    app.use(router.routes());
+
+    const response = await sendRequest(
+      app,
+      createVolcengineEvent({
+        method: 'GET',
+        query: { foo: 'bar' },
+      }) as unknown as Record<string, unknown>,
+      createVolcengineContext() as unknown as Record<string, unknown>,
+    );
+    expect(response.statusCode).toEqual(200);
+    expect(response.body).toEqual('bar');
+  });
+
+  it('should match verbs', async () => {
+    router.get('/api/test', (ctx) => {
+      ctx.status = 200;
+      ctx.body = 'foo';
+    });
+    router.put('/api/test', (ctx) => {
+      ctx.status = 201;
+      ctx.body = 'bar';
+    });
+    app.use(router.routes());
+
+    const response = await sendRequest(
+      app,
+      createVolcengineEvent({ method: 'PUT' }) as unknown as Record<string, unknown>,
+      createVolcengineContext() as unknown as Record<string, unknown>,
+    );
+
+    expect(response.statusCode).toEqual(201);
+    expect(response.body).toEqual('bar');
+  });
+
+  it('should handle custom headers in response', async () => {
+    router.get('/api/test', (ctx) => {
+      ctx.set('X-Custom-Header', 'custom-value');
+      ctx.status = 200;
+      ctx.body = 'ok';
+    });
+    app.use(router.routes());
+
+    const response = await sendRequest(
+      app,
+      createVolcengineEvent() as unknown as Record<string, unknown>,
+      createVolcengineContext() as unknown as Record<string, unknown>,
+    );
+
+    expect(response.statusCode).toEqual(200);
+    expect(response.headers['x-custom-header']).toEqual('custom-value');
+  });
+
+  it('should handle response with JSON', async () => {
+    router.get('/api/test', (ctx) => {
+      ctx.status = 200;
+      ctx.body = { message: 'hello', count: 42 };
+    });
+    app.use(router.routes());
+
+    const response = await sendRequest(
+      app,
+      createVolcengineEvent() as unknown as Record<string, unknown>,
+      createVolcengineContext() as unknown as Record<string, unknown>,
+    );
+
+    expect(response.statusCode).toEqual(200);
+    expect(JSON.parse(response.body)).toEqual({ message: 'hello', count: 42 });
+  });
+
+  it('should handle error from middleware', async () => {
+    app.use(() => {
+      throw new Error('Koa error');
+    });
+
+    const response = await sendRequest(
+      app,
+      createVolcengineEvent() as unknown as Record<string, unknown>,
+      createVolcengineContext() as unknown as Record<string, unknown>,
+    );
+
+    expect(response.statusCode).toEqual(500);
+  });
+
+  it('should handle 404 response', async () => {
+    router.get('/api/exists', (ctx) => {
+      ctx.status = 200;
+      ctx.body = 'exists';
+    });
+    app.use(router.routes());
+
+    const response = await sendRequest(
+      app,
+      createVolcengineEvent({
+        method: 'GET',
+        path: '/api/notexists',
+      }) as unknown as Record<string, unknown>,
+      createVolcengineContext() as unknown as Record<string, unknown>,
+    );
+
+    expect(response.statusCode).toEqual(404);
+  });
+});

--- a/tests/index-volcengine.spec.test.ts
+++ b/tests/index-volcengine.spec.test.ts
@@ -1,0 +1,259 @@
+import express, { Express, Request, Response } from 'express4';
+import bodyParser from 'body-parser';
+import { createVolcengineContext, createVolcengineEvent } from './fixtures/volcengineContext';
+import { sendRequest } from './fixtures/requestHelper';
+
+describe('Volcengine veFaaS with Express 4.x', () => {
+  let app: Express;
+
+  beforeEach(() => {
+    app = express();
+  });
+
+  it('basic middleware should set statusCode and default body', async () => {
+    app.use((req: Request, res: Response) => {
+      res.status(418).send(`I'm a teapot`);
+    });
+
+    const response = await sendRequest(
+      app,
+      createVolcengineEvent() as unknown as Record<string, unknown>,
+      createVolcengineContext() as unknown as Record<string, unknown>,
+    );
+    expect(response.statusCode).toEqual(418);
+    expect(response.body).toEqual(`I'm a teapot`);
+  });
+
+  it('basic middleware should get json body', async () => {
+    app.use(bodyParser.json());
+    app.use((req: Request, res: Response) => {
+      res.status(200).send(req.body.hello);
+    });
+
+    const response = await sendRequest(
+      app,
+      createVolcengineEvent({
+        method: 'POST',
+        body: JSON.stringify({ hello: 'world' }),
+        headers: { 'Content-Type': 'application/json' },
+      }) as unknown as Record<string, unknown>,
+      createVolcengineContext() as unknown as Record<string, unknown>,
+    );
+
+    expect(response.statusCode).toEqual(200);
+    expect(response.body).toEqual('world');
+  });
+
+  it('basic middleware should get query params', async () => {
+    app.use((req: Request, res: Response) => {
+      res.status(200).send(req.query.foo as string);
+    });
+
+    const response = await sendRequest(
+      app,
+      createVolcengineEvent({
+        method: 'GET',
+        query: { foo: 'bar' },
+      }) as unknown as Record<string, unknown>,
+      createVolcengineContext() as unknown as Record<string, unknown>,
+    );
+    expect(response.statusCode).toEqual(200);
+    expect(response.body).toEqual('bar');
+  });
+
+  it('should match verbs', async () => {
+    app.get('/*', (req: Request, res: Response) => {
+      res.status(200).send('foo');
+    });
+    app.put('/*', (req: Request, res: Response) => {
+      res.status(201).send('bar');
+    });
+
+    const response = await sendRequest(
+      app,
+      createVolcengineEvent({ method: 'PUT' }) as unknown as Record<string, unknown>,
+      createVolcengineContext() as unknown as Record<string, unknown>,
+    );
+
+    expect(response.statusCode).toEqual(201);
+    expect(response.body).toEqual('bar');
+  });
+
+  it('should handle DELETE method', async () => {
+    app.delete('/*', (req: Request, res: Response) => {
+      res.status(204).send('deleted');
+    });
+
+    const response = await sendRequest(
+      app,
+      createVolcengineEvent({ method: 'DELETE' }) as unknown as Record<string, unknown>,
+      createVolcengineContext() as unknown as Record<string, unknown>,
+    );
+    expect(response.statusCode).toEqual(204);
+  });
+
+  it('should handle PATCH method', async () => {
+    app.patch('/*', (req: Request, res: Response) => {
+      res.status(200).send('patched');
+    });
+
+    const response = await sendRequest(
+      app,
+      createVolcengineEvent({
+        method: 'PATCH',
+        body: JSON.stringify({ update: 'value' }),
+        headers: { 'Content-Type': 'application/json' },
+      }) as unknown as Record<string, unknown>,
+      createVolcengineContext() as unknown as Record<string, unknown>,
+    );
+    expect(response.statusCode).toEqual(200);
+    expect(response.body).toEqual('patched');
+  });
+
+  it('should handle custom headers in response', async () => {
+    app.use((req: Request, res: Response) => {
+      res.setHeader('X-Custom-Header', 'custom-value');
+      res.setHeader('X-Another', 'another-value');
+      res.status(200).send('ok');
+    });
+
+    const response = await sendRequest(
+      app,
+      createVolcengineEvent() as unknown as Record<string, unknown>,
+      createVolcengineContext() as unknown as Record<string, unknown>,
+    );
+
+    expect(response.statusCode).toEqual(200);
+    expect(response.headers['x-custom-header']).toEqual('custom-value');
+    expect(response.headers['x-another']).toEqual('another-value');
+  });
+
+  it('should handle response with JSON', async () => {
+    app.use((req: Request, res: Response) => {
+      res.status(200).json({ message: 'hello', count: 42 });
+    });
+
+    const response = await sendRequest(
+      app,
+      createVolcengineEvent() as unknown as Record<string, unknown>,
+      createVolcengineContext() as unknown as Record<string, unknown>,
+    );
+
+    expect(response.statusCode).toEqual(200);
+    expect(JSON.parse(response.body)).toEqual({ message: 'hello', count: 42 });
+  });
+
+  it('should handle empty response body', async () => {
+    app.use((req: Request, res: Response) => {
+      res.status(204).end();
+    });
+
+    const response = await sendRequest(
+      app,
+      createVolcengineEvent() as unknown as Record<string, unknown>,
+      createVolcengineContext() as unknown as Record<string, unknown>,
+    );
+
+    expect(response.statusCode).toEqual(204);
+    expect(response.body).toEqual('');
+  });
+
+  it('should handle 500 error from middleware', async () => {
+    app.use(() => {
+      throw new Error('Internal server error');
+    });
+
+    const response = await sendRequest(
+      app,
+      createVolcengineEvent() as unknown as Record<string, unknown>,
+      createVolcengineContext() as unknown as Record<string, unknown>,
+    );
+
+    expect(response.statusCode).toEqual(500);
+  });
+
+  it('should handle request with multiple query parameters', async () => {
+    app.use((req: Request, res: Response) => {
+      res.status(200).json(req.query);
+    });
+
+    const response = await sendRequest(
+      app,
+      createVolcengineEvent({
+        method: 'GET',
+        query: {
+          foo: 'bar',
+          baz: 'qux',
+          num: '123',
+        },
+      }) as unknown as Record<string, unknown>,
+      createVolcengineContext() as unknown as Record<string, unknown>,
+    );
+
+    expect(response.statusCode).toEqual(200);
+    expect(JSON.parse(response.body)).toEqual({
+      foo: 'bar',
+      baz: 'qux',
+      num: '123',
+    });
+  });
+
+  it('should handle 404 response', async () => {
+    app.get('/api/exists', (req: Request, res: Response) => {
+      res.status(200).send('exists');
+    });
+
+    const response = await sendRequest(
+      app,
+      createVolcengineEvent({
+        method: 'GET',
+        path: '/api/notexists',
+      }) as unknown as Record<string, unknown>,
+      createVolcengineContext() as unknown as Record<string, unknown>,
+    );
+
+    expect(response.statusCode).toEqual(404);
+  });
+
+  it('should return Volcengine veFaaS response format', async () => {
+    app.use((req: Request, res: Response) => {
+      res.status(200).json({ provider: 'volcengine' });
+    });
+
+    const response = await sendRequest(
+      app,
+      createVolcengineEvent() as unknown as Record<string, unknown>,
+      createVolcengineContext() as unknown as Record<string, unknown>,
+    );
+
+    expect(response).toHaveProperty('statusCode');
+    expect(response).toHaveProperty('body');
+    expect(response).toHaveProperty('headers');
+  });
+
+  it('should handle request context from Volcengine', async () => {
+    app.use((req: Request, res: Response) => {
+      res.status(200).json({
+        requestId: req.headers['x-request-id'] || 'unknown',
+      });
+    });
+
+    const response = await sendRequest(
+      app,
+      createVolcengineEvent({
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        requestContext: {
+          requestId: 'volcengine-req-12345',
+          stage: 'release',
+          serviceId: 'service-abc',
+        },
+      }) as unknown as Record<string, unknown>,
+      createVolcengineContext() as unknown as Record<string, unknown>,
+    );
+
+    expect(response.statusCode).toEqual(200);
+  });
+});

--- a/tests/unit/index.test.ts
+++ b/tests/unit/index.test.ts
@@ -170,7 +170,7 @@ describe('serverlessAdapter', () => {
 
   it('should use explicit provider when specified', async () => {
     const app = express();
-    app.get('/test', (req, res) => {
+    app.get('/api/test', (req, res) => {
       res.status(200).json({ message: 'tencent success' });
     });
 
@@ -186,13 +186,12 @@ describe('serverlessAdapter', () => {
 
   it('should handle Tencent SCF event correctly', async () => {
     const app = express();
-    app.get('/test', (req, res) => {
+    app.get('/api/test', (req, res) => {
       res.status(200).json({ message: 'tencent handler' });
     });
 
     const handler = serverlessAdapter(app);
     const tencentEvent = createTencentEvent({
-      path: '/test',
       httpMethod: 'GET',
     });
     const tencentContext = createTencentContext();

--- a/tests/unit/providers/aliyun.test.ts
+++ b/tests/unit/providers/aliyun.test.ts
@@ -193,6 +193,13 @@ describe('AliyunProvider', () => {
           accessKeySecret: 'test-secret',
           securityToken: '',
         },
+        function: {
+          name: 'test-function',
+          handler: 'index.handler',
+          memory: 128,
+          timeout: 30,
+          initializer: '',
+        },
       };
 
       expect(provider.detect(rawEvent, context as AliyunApiGatewayContext)).toBe(true);

--- a/tests/unit/providers/index.test.ts
+++ b/tests/unit/providers/index.test.ts
@@ -4,11 +4,13 @@ import {
   getAllProviders,
   AliyunProvider,
   TencentProvider,
+  VolcengineProvider,
 } from '../../../src/providers';
 import { defaultContext } from '../../fixtures/fcContext';
 import { createTencentContext, createTencentEvent } from '../../fixtures/tencentContext';
+import { createVolcengineContext, createVolcengineEvent } from '../../fixtures/volcengineContext';
 import { AliyunApiGatewayContext } from '../../../src/types/aliyun';
-import { TencentScfContext } from '../../../src/types/tencent';
+import { VolcengineVefaasContext } from '../../../src/types/volcengine';
 
 describe('providers/index', () => {
   describe('getProvider', () => {
@@ -22,8 +24,13 @@ describe('providers/index', () => {
       expect(provider).toBeInstanceOf(TencentProvider);
     });
 
+    it('should return VolcengineProvider for "volcengine"', () => {
+      const provider = getProvider('volcengine');
+      expect(provider).toBeInstanceOf(VolcengineProvider);
+    });
+
     it('should return undefined for unknown provider', () => {
-      const provider = getProvider('unknown' as 'aliyun' | 'tencent');
+      const provider = getProvider('unknown' as 'aliyun' | 'tencent' | 'volcengine');
       expect(provider).toBeUndefined();
     });
   });
@@ -42,10 +49,17 @@ describe('providers/index', () => {
       expect(provider?.name).toBe('tencent');
     });
 
+    it('should detect Volcengine provider', () => {
+      const rawEvent = Buffer.from(JSON.stringify(createVolcengineEvent()));
+      const context = createVolcengineContext();
+      const provider = detectProvider(rawEvent, context);
+      expect(provider?.name).toBe('volcengine');
+    });
+
     it('should return undefined when no provider matches', () => {
       const rawEvent = Buffer.from(JSON.stringify({}));
       const context = { unknown: true };
-      const provider = detectProvider(rawEvent, context as unknown as TencentScfContext);
+      const provider = detectProvider(rawEvent, context as unknown as VolcengineVefaasContext);
       expect(provider).toBeUndefined();
     });
   });
@@ -53,9 +67,10 @@ describe('providers/index', () => {
   describe('getAllProviders', () => {
     it('should return map of all providers', () => {
       const providers = getAllProviders();
-      expect(providers.size).toBe(2);
+      expect(providers.size).toBe(3);
       expect(providers.has('aliyun')).toBe(true);
       expect(providers.has('tencent')).toBe(true);
+      expect(providers.has('volcengine')).toBe(true);
     });
   });
 });

--- a/tests/unit/providers/volcengine.test.ts
+++ b/tests/unit/providers/volcengine.test.ts
@@ -1,0 +1,346 @@
+import { VolcengineProvider } from '../../../src/providers/volcengine';
+import { VolcengineApiGatewayEvent, VolcengineVefaasContext } from '../../../src/types/volcengine';
+import { createVolcengineEvent, createVolcengineContext } from '../../fixtures/volcengineContext';
+
+describe('VolcengineProvider', () => {
+  let provider: VolcengineProvider;
+
+  beforeEach(() => {
+    provider = new VolcengineProvider();
+  });
+
+  describe('name', () => {
+    it('should return "volcengine"', () => {
+      expect(provider.name).toBe('volcengine');
+    });
+  });
+
+  describe('normalizeEvent', () => {
+    it('should normalize API Gateway event to ServerlessEvent', () => {
+      const volcengineEvent: VolcengineApiGatewayEvent = {
+        path: '/api/users',
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        query: { page: '1' },
+        body: '{"name":"test"}',
+        requestContext: {
+          requestId: 'req-abc',
+          stage: 'release',
+          serviceId: 'service-123',
+        },
+      };
+
+      const rawEvent = Buffer.from(JSON.stringify(volcengineEvent));
+      const result = provider.normalizeEvent(rawEvent);
+
+      expect(result.path).toBe('/api/users');
+      expect(result.httpMethod).toBe('POST');
+      expect(result.body).toBe('{"name":"test"}');
+      expect(result.headers).toEqual({ 'content-type': 'application/json' });
+      expect(result.queryParameters).toEqual({ page: '1' });
+      expect(result.isBase64Encoded).toBe(false);
+    });
+
+    it('should handle event with no body', () => {
+      const volcengineEvent = createVolcengineEvent({
+        method: 'GET',
+        body: '',
+      });
+
+      const rawEvent = Buffer.from(JSON.stringify(volcengineEvent));
+      const result = provider.normalizeEvent(rawEvent);
+
+      expect(result.body).toBe('');
+    });
+
+    it('should handle event without headers (use fallback)', () => {
+      const volcengineEvent = createVolcengineEvent({
+        headers: undefined as unknown as Record<string, string>,
+      });
+
+      const rawEvent = Buffer.from(JSON.stringify(volcengineEvent));
+      const result = provider.normalizeEvent(rawEvent);
+
+      expect(result.headers).toEqual({});
+    });
+
+    it('should handle event without query (use fallback)', () => {
+      const volcengineEvent = createVolcengineEvent({
+        query: undefined as unknown as Record<string, string>,
+      });
+
+      const rawEvent = Buffer.from(JSON.stringify(volcengineEvent));
+      const result = provider.normalizeEvent(rawEvent);
+
+      expect(result.queryParameters).toEqual({});
+    });
+  });
+
+  describe('createRequest', () => {
+    it('should create ServerlessRequest from normalized event', () => {
+      const event = {
+        path: '/test',
+        httpMethod: 'POST',
+        headers: { 'content-type': 'application/json' },
+        queryParameters: { foo: 'bar' },
+        pathParameters: {},
+        body: '{"key":"value"}',
+        isBase64Encoded: false,
+      };
+
+      const { request, isBase64Encoded } = provider.createRequest(event);
+
+      expect(request.method).toBe('POST');
+      expect(request.url).toBe('/test?foo=bar');
+      expect(request.headers['content-type']).toBe('application/json');
+      expect(isBase64Encoded).toBe(false);
+    });
+
+    it('should create request with base64 encoded body', () => {
+      const originalBody = 'hello world';
+      const base64Body = Buffer.from(originalBody).toString('base64');
+      const event = {
+        path: '/test',
+        httpMethod: 'POST',
+        headers: {},
+        queryParameters: {},
+        pathParameters: {},
+        body: base64Body,
+        isBase64Encoded: true,
+      };
+
+      const { request, isBase64Encoded } = provider.createRequest(event);
+
+      expect(isBase64Encoded).toBe(true);
+      expect(request.body?.toString()).toBe(originalBody);
+    });
+
+    it('should handle query parameters in URL', () => {
+      const event = {
+        path: '/search',
+        httpMethod: 'GET',
+        headers: {},
+        queryParameters: { q: 'test', page: '1' },
+        pathParameters: {},
+        body: undefined,
+        isBase64Encoded: false,
+      };
+
+      const { request } = provider.createRequest(event);
+
+      expect(request.url).toContain('q=test');
+      expect(request.url).toContain('page=1');
+    });
+
+    it('should handle Buffer body', () => {
+      const bufferBody = Buffer.from('buffer content');
+      const event = {
+        path: '/test',
+        httpMethod: 'POST',
+        headers: {},
+        queryParameters: {},
+        pathParameters: {},
+        body: bufferBody,
+        isBase64Encoded: false,
+      };
+
+      const { request } = provider.createRequest(event);
+
+      expect(request.body).toBe(bufferBody);
+    });
+
+    it('should handle object body', () => {
+      const event = {
+        path: '/test',
+        httpMethod: 'POST',
+        headers: {},
+        queryParameters: {},
+        pathParameters: {},
+        body: { key: 'value', nested: { foo: 'bar' } },
+        isBase64Encoded: false,
+      };
+
+      const { request } = provider.createRequest(event);
+
+      expect(JSON.parse(request.body?.toString() || '{}')).toEqual({
+        key: 'value',
+        nested: { foo: 'bar' },
+      });
+    });
+
+    it('should handle null headers', () => {
+      const event = {
+        path: '/test',
+        httpMethod: 'GET',
+        headers: null as unknown as Record<string, string>,
+        queryParameters: {},
+        pathParameters: {},
+        body: undefined,
+        isBase64Encoded: false,
+      };
+
+      const { request } = provider.createRequest(event);
+
+      expect(request.headers).toEqual({ 'content-length': '0' });
+    });
+
+    it('should throw error for unexpected body type', () => {
+      const event = {
+        path: '/test',
+        httpMethod: 'POST',
+        headers: {},
+        queryParameters: {},
+        pathParameters: {},
+        body: 123,
+        isBase64Encoded: false,
+      };
+
+      expect(() => provider.createRequest(event)).toThrow('Unexpected event.body type: number');
+    });
+
+    it('should handle event without query parameters', () => {
+      const event = {
+        path: '/test',
+        httpMethod: 'GET',
+        headers: {},
+        queryParameters: {},
+        pathParameters: {},
+        body: undefined,
+        isBase64Encoded: false,
+      };
+
+      const { request } = provider.createRequest(event);
+
+      expect(request.url).toBe('/test');
+    });
+  });
+
+  describe('formatResponse', () => {
+    it('should format response correctly', () => {
+      const response = {
+        statusCode: 200,
+        body: '{"message":"success"}',
+        headers: { 'Content-Type': 'application/json' },
+        isBase64Encoded: false,
+      };
+
+      const result = provider.formatResponse(response);
+
+      expect(result.statusCode).toBe(200);
+      expect(result.body).toBe('{"message":"success"}');
+      expect(result.headers).toEqual({ 'Content-Type': 'application/json' });
+    });
+
+    it('should handle error responses', () => {
+      const response = {
+        statusCode: 500,
+        body: 'Internal Server Error',
+        headers: {},
+        isBase64Encoded: false,
+      };
+
+      const result = provider.formatResponse(response);
+
+      expect(result.statusCode).toBe(500);
+      expect(result.body).toBe('Internal Server Error');
+    });
+  });
+
+  describe('detect', () => {
+    it('should detect Volcengine context by requestId and region', () => {
+      const rawEvent = Buffer.from(JSON.stringify(createVolcengineEvent()));
+      const context = createVolcengineContext();
+
+      expect(provider.detect(rawEvent, context)).toBe(true);
+    });
+
+    it('should detect Volcengine context by accountId', () => {
+      const rawEvent = Buffer.from(JSON.stringify(createVolcengineEvent()));
+      const context = createVolcengineContext({
+        credentials: undefined,
+        function: undefined,
+      });
+
+      expect(provider.detect(rawEvent, context)).toBe(true);
+    });
+
+    it('should detect Volcengine context by credentials', () => {
+      const rawEvent = Buffer.from(JSON.stringify(createVolcengineEvent()));
+      const context = createVolcengineContext({
+        accountId: undefined,
+        function: undefined,
+      });
+
+      expect(provider.detect(rawEvent, context)).toBe(true);
+    });
+
+    it('should detect Volcengine context by function', () => {
+      const rawEvent = Buffer.from(JSON.stringify(createVolcengineEvent()));
+      const context = createVolcengineContext({
+        accountId: undefined,
+        credentials: undefined,
+      });
+
+      expect(provider.detect(rawEvent, context)).toBe(true);
+    });
+
+    it('should detect Volcengine context with service field (without service.name)', () => {
+      const rawEvent = Buffer.from(JSON.stringify(createVolcengineEvent()));
+      const context = createVolcengineContext({
+        service: {
+          logProject: 'test-project',
+          logStore: 'test-store',
+          qualifier: '$LATEST',
+          versionId: 'v1',
+        },
+      });
+
+      expect(provider.detect(rawEvent, context)).toBe(true);
+    });
+
+    it('should not detect non-Volcengine context (missing requestId)', () => {
+      const rawEvent = Buffer.from(JSON.stringify(createVolcengineEvent()));
+      const context = {
+        region: 'cn-beijing',
+        accountId: '123456',
+      };
+
+      expect(provider.detect(rawEvent, context as unknown as VolcengineVefaasContext)).toBe(false);
+    });
+
+    it('should not detect non-Volcengine context (missing region)', () => {
+      const rawEvent = Buffer.from(JSON.stringify(createVolcengineEvent()));
+      const context = {
+        requestId: 'test-id',
+        accountId: '123456',
+      };
+
+      expect(provider.detect(rawEvent, context as unknown as VolcengineVefaasContext)).toBe(false);
+    });
+
+    it('should not detect Aliyun context', () => {
+      const rawEvent = Buffer.from(JSON.stringify({}));
+      const context = {
+        requestId: 'test-id',
+        region: 'cn-hangzhou',
+        accountId: '123456',
+        credentials: { accessKeyId: 'key', accessKeySecret: 'secret', securityToken: '' },
+        service: { name: 'test-service' },
+        tracing: { spanContext: 'span' },
+      };
+
+      expect(provider.detect(rawEvent, context as unknown as VolcengineVefaasContext)).toBe(false);
+    });
+
+    it('should not detect Tencent context', () => {
+      const rawEvent = Buffer.from(JSON.stringify({}));
+      const context = {
+        tencentcloud_region: 'ap-guangzhou',
+        namespace: 'default',
+        tencentcloud_appid: '123456',
+      };
+
+      expect(provider.detect(rawEvent, context as unknown as VolcengineVefaasContext)).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
This pull request adds first-class support for Volcengine veFaaS (函数服务) as a serverless provider for Express and Koa applications. It introduces a new provider implementation, updates the type system to include Volcengine, enhances provider detection logic, and extends documentation and test fixtures accordingly.

**Volcengine veFaaS Support**

* Added a new `VolcengineProvider` class to handle event normalization, response formatting, and provider detection for Volcengine veFaaS. (`src/providers/volcengine.ts`)
* Registered the new provider in the provider registry and exported it for external use. (`src/providers/index.ts`) [[1]](diffhunk://#diff-488ab83f0a405c2ee9bfabd985cc3c87d94d25635829e3b4d6f92d508ac65bc9R4) [[2]](diffhunk://#diff-488ab83f0a405c2ee9bfabd985cc3c87d94d25635829e3b4d6f92d508ac65bc9R35-R40)
* Introduced Volcengine-specific event, context, and response types. (`src/types/volcengine.ts`, `src/types/index.ts`) [[1]](diffhunk://#diff-349e139aef9875594560d5c83cdfb3c13aa78917541ce6a3f27f37d5808ef23cR1-R68) [[2]](diffhunk://#diff-a9ba9cbedd19c9f66d564d2e89912890209b98f0a7ef19187877d2587300e476R12-R18) [[3]](diffhunk://#diff-a9ba9cbedd19c9f66d564d2e89912890209b98f0a7ef19187877d2587300e476R28-R34) [[4]](diffhunk://#diff-a9ba9cbedd19c9f66d564d2e89912890209b98f0a7ef19187877d2587300e476L51-R75)

**Documentation Updates**

* Updated the `README.md` to document Volcengine support, including provider tables, detection fields, usage examples, and API reference. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R18) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R111-R126) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L119-R138) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L142-R162)

**Provider Detection Improvements**

* Refined detection logic for Aliyun and added detection logic for Volcengine to avoid misidentification between providers. (`src/providers/aliyun.ts`, `src/providers/volcengine.ts`) [[1]](diffhunk://#diff-fcf1914caf721403d6104943e7ce99f69b89846c56f42960c1ac31b7d50af294L38-R47) [[2]](diffhunk://#diff-1963e66b65f08971967a89b41e61af2c8ff087d4329273b007be6a6de8da33fbR1-R62)

**Test Fixtures**

* Added Volcengine context and event fixtures for testing. (`tests/fixtures/volcengineContext.ts`)

**Tencent Test Fixture and Test Improvements**

* Updated Tencent test fixtures and added comprehensive tests for Express 5.x and Koa 2.x integrations with Tencent SCF. (`tests/fixtures/tencentContext.ts`, `tests/index-tencent-express-5x.spec.test.ts`, `tests/index-tencent-koa-2x.spec.test.ts`) [[1]](diffhunk://#diff-d984201b86a1ec2afdd3f92caba7a7b825f1e5aad683e79dc27fd5b19c43ecb0L22-R22) [[2]](diffhunk://#diff-d984201b86a1ec2afdd3f92caba7a7b825f1e5aad683e79dc27fd5b19c43ecb0L31-R31) [[3]](diffhunk://#diff-fb8b6885c3182f4b38d2b12f5452aa9f8b560ea58674ed0403eab4ab18e34fc0R1-R142) [[4]](diffhunk://#diff-e9842f25f9d4c9e124f1892c64f003c4cefd4f86f54140a8b5de8242b7ece118R1-R162)