### PR TITLE
feat: AWS Lambda + API Gateway (v1 + v2) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Adapter for web frameworks (Express, Koa, Hono) to run on serverless platforms a
 | Alibaba Cloud (Aliyun) | Function Compute                | ✅ Supported | API Gateway  |
 | Tencent Cloud          | Serverless Cloud Function (SCF) | ✅ Supported | API Gateway  |
 | Volcengine             | veFaaS (函数服务)               | ✅ Supported | API Gateway  |
+| AWS                    | Lambda + API Gateway            | ✅ Supported | API Gateway (REST API v1 & HTTP API v2) |
 
 ## Supported Frameworks
 
@@ -153,7 +154,7 @@ Creates a serverless handler for your Express, Koa, or Hono application.
 | Parameter          | Type                                    | Required | Description                                                  |
 | ------------------ | --------------------------------------- | -------- | ------------------------------------------------------------ |
 | `app`              | `Express \| Koa \| Hono`               | Yes      | Express, Koa, or Hono application instance                  |
-| `options.provider` | `'aliyun' \| 'tencent' \| 'volcengine'` | No       | Explicitly specify cloud provider (auto-detected if omitted) |
+| `options.provider` | `'aliyun' \| 'tencent' \| 'volcengine' \| 'aws'` | No       | Explicitly specify cloud provider (auto-detected if omitted) |
 
 #### Returns
 
@@ -178,6 +179,7 @@ The adapter automatically detects the cloud provider by examining the `context` 
 | Aliyun     | `service.name`, `tracing`, `logger`, `function.memory`   |
 | Tencent    | `tencentcloud_region`, `tencentcloud_appid`, `namespace` |
 | Volcengine | `requestId`, `region`, `function.memoryMb`               |
+| AWS        | `awsRequestId`, `invokedFunctionArn`, `functionName`     |
 
 ## License
 

--- a/src/providers/aws.ts
+++ b/src/providers/aws.ts
@@ -1,0 +1,88 @@
+import { BaseProvider } from './base';
+import {
+  ServerlessEvent,
+  ServerlessResponse,
+  ProviderContext,
+  ProviderEvent,
+  AwsResponse,
+} from '../types';
+
+/**
+ * AWS Lambda + API Gateway Provider
+ * Supports both REST API v1 and HTTP API v2 event formats
+ */
+export class AWSProvider extends BaseProvider {
+  readonly name = 'aws' as const;
+
+  normalizeEvent(rawEvent: ProviderEvent): ServerlessEvent {
+    let raw: Record<string, unknown>;
+    if (Buffer.isBuffer(rawEvent)) {
+      raw = JSON.parse(rawEvent.toString());
+    } else if (typeof rawEvent === 'string') {
+      raw = JSON.parse(rawEvent);
+    } else {
+      raw = rawEvent as Record<string, unknown>;
+    }
+
+    if (isV2Event(raw)) {
+      return {
+        path: (raw.rawPath as string) || '/',
+        httpMethod: extractMethodFromRouteKey(raw.routeKey as string) || 'GET',
+        headers: (raw.headers as Record<string, string>) || {},
+        queryParameters:
+          (raw.queryStringParameters as Record<string, string>) ||
+          parseQueryString(raw.rawQueryString as string) ||
+          {},
+        pathParameters: (raw.pathParameters as Record<string, string>) || {},
+        body: (raw.body as string) ?? undefined,
+        isBase64Encoded: (raw.isBase64Encoded as boolean) || false,
+      };
+    }
+
+    // v1 (REST API)
+    return {
+      path: (raw.path as string) || '/',
+      httpMethod: (raw.httpMethod as string) || 'GET',
+      headers: (raw.headers as Record<string, string>) || {},
+      queryParameters: (raw.queryStringParameters as Record<string, string>) || {},
+      pathParameters: (raw.pathParameters as Record<string, string>) || {},
+      body: (raw.body as string) ?? undefined,
+      isBase64Encoded: (raw.isBase64Encoded as boolean) || false,
+    };
+  }
+
+  formatResponse(response: ServerlessResponse): AwsResponse {
+    return {
+      statusCode: response.statusCode,
+      body: response.body,
+      headers: response.headers,
+      isBase64Encoded: response.isBase64Encoded,
+      multiValueHeaders: (response as Record<string, unknown>).multiValueHeaders as
+        | { [key: string]: string[] }
+        | undefined,
+    };
+  }
+
+  detect(_rawEvent: ProviderEvent, rawContext: ProviderContext): boolean {
+    const ctx = rawContext as Record<string, unknown>;
+    return !!(ctx.awsRequestId || ctx.invokedFunctionArn || ctx.functionName);
+  }
+}
+
+function isV2Event(event: Record<string, unknown>): boolean {
+  return event.version === '2.0';
+}
+
+function extractMethodFromRouteKey(routeKey: string): string {
+  return routeKey?.split(' ')[0] || 'GET';
+}
+
+function parseQueryString(raw: string): Record<string, string> {
+  if (!raw) return {};
+  const params: Record<string, string> = {};
+  for (const part of raw.split('&')) {
+    const [key, value] = part.split('=');
+    if (key) params[decodeURIComponent(key)] = value ? decodeURIComponent(value) : '';
+  }
+  return params;
+}

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -2,6 +2,7 @@ import { ServerlessProvider } from './base';
 import { AliyunProvider } from './aliyun';
 import { TencentProvider } from './tencent';
 import { VolcengineProvider } from './volcengine';
+import { AWSProvider } from './aws';
 import { CloudProvider, ProviderContext, ProviderEvent } from '../types';
 
 const providers: Map<CloudProvider, ServerlessProvider> = new Map();
@@ -33,8 +34,10 @@ export function getAllProviders(): Map<CloudProvider, ServerlessProvider> {
 registerProvider(new AliyunProvider());
 registerProvider(new TencentProvider());
 registerProvider(new VolcengineProvider());
+registerProvider(new AWSProvider());
 
 export { ServerlessProvider } from './base';
 export { AliyunProvider } from './aliyun';
 export { TencentProvider } from './tencent';
 export { VolcengineProvider } from './volcengine';
+export { AWSProvider } from './aws';

--- a/src/types/aws.ts
+++ b/src/types/aws.ts
@@ -1,0 +1,118 @@
+import { IncomingHttpHeaders } from 'http';
+
+/**
+ * API Gateway v1 (REST API) Event
+ * @see https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-vs-rest.html
+ */
+export interface AwsApiGatewayV1Event {
+  path: string;
+  httpMethod: string;
+  headers: Record<string, string>;
+  queryStringParameters?: Record<string, string>;
+  pathParameters?: Record<string, string>;
+  body: string | null;
+  isBase64Encoded: boolean;
+  requestContext: {
+    stage: string;
+    requestId: string;
+    identity: {
+      sourceIp?: string;
+    };
+    [key: string]: unknown;
+  };
+  multiValueHeaders?: Record<string, string[]>;
+  multiValueQueryStringParameters?: Record<string, string[]>;
+  stageVariables?: Record<string, string>;
+}
+
+/**
+ * API Gateway v2 (HTTP API) Event
+ * @see https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-vs-rest.html
+ */
+export interface AwsApiGatewayV2Event {
+  version: '2.0';
+  routeKey: string;
+  rawPath: string;
+  rawQueryString: string;
+  headers: Record<string, string>;
+  queryStringParameters?: Record<string, string>;
+  pathParameters?: Record<string, string>;
+  body: string | null;
+  isBase64Encoded: boolean;
+  requestContext: {
+    stage: string;
+    requestId: string;
+    time: string;
+    timeEpoch: number;
+    http: {
+      method: string;
+      path: string;
+      protocol: string;
+      sourceIp: string;
+      userAgent: string;
+    };
+    [key: string]: unknown;
+  };
+  stageVariables?: Record<string, string>;
+  cookies?: string[];
+}
+
+/**
+ * AWS Lambda Context Object
+ * @see https://docs.aws.amazon.com/lambda/latest/dg/nodejs-context.html
+ */
+export interface AwsLambdaContext {
+  awsRequestId: string;
+  invokedFunctionArn: string;
+  functionName: string;
+  memoryLimitInMB: string;
+  logGroupName: string;
+  logStreamName: string;
+  getRemainingTimeInMillis: () => number;
+  callbackWaitsForEmptyEventLoop: boolean;
+  done: (error?: Error, result?: unknown) => void;
+  fail: (error: Error | string) => void;
+  succeed: (result: unknown) => void;
+  identity?: {
+    cognitoIdentityId: string;
+    cognitoIdentityPoolId: string;
+  };
+  clientContext?: {
+    client: {
+      installation_id: string;
+      app_title: string;
+      app_version_name: string;
+      app_version_code: string;
+      app_package_name: string;
+    };
+    env: {
+      platform_version: string;
+      platform: string;
+      make: string;
+      model: string;
+      locale: string;
+    };
+    Custom: unknown;
+  };
+}
+
+/**
+ * AwsEvent is a Buffer containing JSON (like other providers)
+ */
+export type AwsEvent = Buffer;
+
+/**
+ * AWS Response for API Gateway integration
+ */
+export interface AwsResponse {
+  statusCode: number;
+  headers: IncomingHttpHeaders;
+  body: string;
+  isBase64Encoded: boolean;
+  multiValueHeaders?: { [key: string]: string[] };
+}
+
+/**
+ * AWS Lambda Handler Type
+ */
+export type AwsHandler = (event: AwsEvent, context: AwsLambdaContext) => Promise<AwsResponse>;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -16,6 +16,14 @@ import {
   VolcengineEvent,
   VolcengineHandler,
 } from './volcengine';
+import {
+  AwsApiGatewayV1Event,
+  AwsApiGatewayV2Event,
+  AwsLambdaContext,
+  AwsResponse,
+  AwsEvent,
+  AwsHandler,
+} from './aws';
 
 export { AliyunApiGatewayContext, AliyunEvent, AliyunResponse };
 export {
@@ -31,6 +39,14 @@ export {
   VolcengineVefaasResponse,
   VolcengineEvent,
   VolcengineHandler,
+};
+export {
+  AwsApiGatewayV1Event,
+  AwsApiGatewayV2Event,
+  AwsLambdaContext,
+  AwsResponse,
+  AwsEvent,
+  AwsHandler,
 };
 
 export type Context = AliyunApiGatewayContext;
@@ -68,17 +84,21 @@ export type ServerlessResponse = {
 /**
  * Supported cloud providers
  */
-export type CloudProvider = 'aliyun' | 'tencent' | 'volcengine';
+export type CloudProvider = 'aliyun' | 'tencent' | 'volcengine' | 'aws';
 
 /**
  * Provider-specific context types
  */
-export type ProviderContext = AliyunApiGatewayContext | TencentScfContext | VolcengineVefaasContext;
+export type ProviderContext =
+  | AliyunApiGatewayContext
+  | TencentScfContext
+  | VolcengineVefaasContext
+  | AwsLambdaContext;
 
 /**
  * Provider-specific event types
  */
-export type ProviderEvent = AliyunEvent | TencentEvent | VolcengineEvent;
+export type ProviderEvent = AliyunEvent | TencentEvent | VolcengineEvent | AwsEvent;
 
 export type ServerlessAdapter = (app: Express | Application | HonoApp) => (
   event: Event,

--- a/tests/fixtures/awsContext.ts
+++ b/tests/fixtures/awsContext.ts
@@ -1,0 +1,80 @@
+import { AwsApiGatewayV1Event, AwsApiGatewayV2Event, AwsLambdaContext } from '../../src/types/aws';
+
+export const defaultAwsContext: AwsLambdaContext = {
+  awsRequestId: 'aws-request-id-12345',
+  invokedFunctionArn: 'arn:aws:lambda:us-east-1:123456789012:function:test-function',
+  functionName: 'test-function',
+  memoryLimitInMB: '128',
+  logGroupName: '/aws/lambda/test-function',
+  logStreamName: '2026/07/27/[$LATEST]abc123',
+  getRemainingTimeInMillis: () => 3000,
+  callbackWaitsForEmptyEventLoop: true,
+  done: () => {},
+  fail: () => {},
+  succeed: () => {},
+};
+
+export const defaultAwsApiGatewayV1Event: AwsApiGatewayV1Event = {
+  path: '/api/test',
+  httpMethod: 'GET',
+  headers: {
+    'Content-Type': 'application/json',
+  },
+  queryStringParameters: {},
+  pathParameters: {},
+  body: null,
+  isBase64Encoded: false,
+  requestContext: {
+    stage: 'dev',
+    requestId: 'req-12345',
+    identity: {
+      sourceIp: '192.168.1.1',
+    },
+  },
+};
+
+export const defaultAwsApiGatewayV2Event: AwsApiGatewayV2Event = {
+  version: '2.0',
+  routeKey: 'GET /api/test',
+  rawPath: '/api/test',
+  rawQueryString: '',
+  headers: {
+    'Content-Type': 'application/json',
+  },
+  queryStringParameters: {},
+  pathParameters: {},
+  body: null,
+  isBase64Encoded: false,
+  requestContext: {
+    stage: '$default',
+    requestId: 'req-67890',
+    time: '27/Jul/2026:12:00:00 +0000',
+    timeEpoch: 1722072000000,
+    http: {
+      method: 'GET',
+      path: '/api/test',
+      protocol: 'HTTP/1.1',
+      sourceIp: '10.0.0.1',
+      userAgent: 'test-agent',
+    },
+  },
+};
+
+export const createAwsV1Event = (
+  overrides: Partial<AwsApiGatewayV1Event> = {},
+): AwsApiGatewayV1Event => ({
+  ...defaultAwsApiGatewayV1Event,
+  ...overrides,
+});
+
+export const createAwsV2Event = (
+  overrides: Partial<AwsApiGatewayV2Event> = {},
+): AwsApiGatewayV2Event => ({
+  ...defaultAwsApiGatewayV2Event,
+  ...overrides,
+});
+
+export const createAwsContext = (overrides: Partial<AwsLambdaContext> = {}): AwsLambdaContext => ({
+  ...defaultAwsContext,
+  ...overrides,
+});

--- a/tests/index-aws-hono.spec.test.ts
+++ b/tests/index-aws-hono.spec.test.ts
@@ -1,0 +1,95 @@
+import { Hono } from 'hono';
+import { createAwsContext, createAwsV1Event, createAwsV2Event } from './fixtures/awsContext';
+import { sendRequest } from './fixtures/requestHelper';
+
+describe('AWS Lambda + API Gateway with Hono', () => {
+  it('should handle basic GET request with v1 event', async () => {
+    const app = new Hono();
+    app.get('/', (c) => c.json({ message: 'Hello from AWS Hono!' }));
+
+    const response = await sendRequest(
+      app,
+      createAwsV1Event({
+        httpMethod: 'GET',
+        path: '/',
+      }) as unknown as Record<string, unknown>,
+      createAwsContext() as unknown as Record<string, unknown>,
+    );
+
+    expect(response.statusCode).toEqual(200);
+    expect(JSON.parse(response.body)).toEqual({ message: 'Hello from AWS Hono!' });
+  });
+
+  it('should handle basic GET request with v2 event', async () => {
+    const app = new Hono();
+    app.get('/', (c) => c.json({ version: '2.0' }));
+
+    const response = await sendRequest(
+      app,
+      createAwsV2Event({
+        routeKey: 'GET /',
+        rawPath: '/',
+      }) as unknown as Record<string, unknown>,
+      createAwsContext() as unknown as Record<string, unknown>,
+    );
+
+    expect(response.statusCode).toEqual(200);
+    expect(JSON.parse(response.body)).toEqual({ version: '2.0' });
+  });
+
+  it('should accept query parameters', async () => {
+    const app = new Hono();
+    app.get('/search', (c) => c.json({ q: c.req.query('q') }));
+
+    const response = await sendRequest(
+      app,
+      createAwsV1Event({
+        httpMethod: 'GET',
+        path: '/search',
+        queryStringParameters: { q: 'test' },
+      }) as unknown as Record<string, unknown>,
+      createAwsContext() as unknown as Record<string, unknown>,
+    );
+
+    expect(response.statusCode).toEqual(200);
+    expect(JSON.parse(response.body)).toEqual({ q: 'test' });
+  });
+
+  it('should accept JSON body', async () => {
+    const app = new Hono();
+    app.post('/submit', async (c) => {
+      const body = await c.req.json();
+      return c.json({ received: body });
+    });
+
+    const response = await sendRequest(
+      app,
+      createAwsV1Event({
+        httpMethod: 'POST',
+        path: '/submit',
+        body: JSON.stringify({ name: 'test' }),
+        headers: { 'Content-Type': 'application/json' },
+      }) as unknown as Record<string, unknown>,
+      createAwsContext() as unknown as Record<string, unknown>,
+    );
+
+    expect(response.statusCode).toEqual(200);
+    expect(JSON.parse(response.body)).toEqual({ received: { name: 'test' } });
+  });
+
+  it('should handle 404', async () => {
+    const app = new Hono();
+    app.get('/exists', (c) => c.text('ok'));
+
+    const response = await sendRequest(
+      app,
+      createAwsV1Event({
+        httpMethod: 'GET',
+        path: '/notexists',
+      }) as unknown as Record<string, unknown>,
+      createAwsContext() as unknown as Record<string, unknown>,
+    );
+
+    expect(response.statusCode).toEqual(404);
+  });
+});

--- a/tests/index-aws-koa-2x.spec.test.ts
+++ b/tests/index-aws-koa-2x.spec.test.ts
@@ -1,0 +1,167 @@
+import Koa from 'koa2';
+import Router from '@koa/router';
+import { createAwsContext, createAwsV1Event } from './fixtures/awsContext';
+import { sendRequest } from './fixtures/requestHelper';
+
+describe('AWS Lambda + API Gateway with Koa 2.x', () => {
+  let app: Koa;
+
+  beforeEach(() => {
+    app = new Koa();
+  });
+
+  it('basic middleware should set statusCode and default body', async () => {
+    app.use((ctx) => {
+      ctx.status = 418;
+      ctx.body = `I'm a teapot`;
+    });
+
+    const response = await sendRequest(
+      app,
+      createAwsV1Event() as unknown as Record<string, unknown>,
+      createAwsContext() as unknown as Record<string, unknown>,
+    );
+    expect(response.statusCode).toEqual(418);
+    expect(response.body).toEqual(`I'm a teapot`);
+  });
+
+  it('should get query params', async () => {
+    app.use((ctx) => {
+      ctx.status = 200;
+      ctx.body = ctx.query.foo as string;
+    });
+
+    const response = await sendRequest(
+      app,
+      createAwsV1Event({
+        httpMethod: 'GET',
+        queryStringParameters: { foo: 'bar' },
+      }) as unknown as Record<string, unknown>,
+      createAwsContext() as unknown as Record<string, unknown>,
+    );
+    expect(response.statusCode).toEqual(200);
+    expect(response.body).toEqual('bar');
+  });
+
+  it('should handle POST with JSON body', async () => {
+    app.use(async (ctx) => {
+      ctx.status = 200;
+      ctx.body = { received: ctx.request.body || ctx.query };
+    });
+
+    const response = await sendRequest(
+      app,
+      createAwsV1Event({
+        httpMethod: 'POST',
+        body: JSON.stringify({ hello: 'world' }),
+        headers: { 'Content-Type': 'application/json' },
+      }) as unknown as Record<string, unknown>,
+      createAwsContext() as unknown as Record<string, unknown>,
+    );
+    expect(response.statusCode).toEqual(200);
+  });
+
+  it('should handle custom headers in response', async () => {
+    app.use((ctx) => {
+      ctx.set('X-Custom-Header', 'custom-value');
+      ctx.set('X-Another', 'another-value');
+      ctx.status = 200;
+      ctx.body = 'ok';
+    });
+
+    const response = await sendRequest(
+      app,
+      createAwsV1Event() as unknown as Record<string, unknown>,
+      createAwsContext() as unknown as Record<string, unknown>,
+    );
+
+    expect(response.statusCode).toEqual(200);
+    expect(response.headers['x-custom-header']).toEqual('custom-value');
+    expect(response.headers['x-another']).toEqual('another-value');
+  });
+
+  it('should handle response with JSON', async () => {
+    app.use((ctx) => {
+      ctx.status = 200;
+      ctx.body = { message: 'hello', count: 42 };
+    });
+
+    const response = await sendRequest(
+      app,
+      createAwsV1Event() as unknown as Record<string, unknown>,
+      createAwsContext() as unknown as Record<string, unknown>,
+    );
+
+    expect(response.statusCode).toEqual(200);
+    expect(JSON.parse(response.body)).toEqual({ message: 'hello', count: 42 });
+  });
+
+  it('should handle empty response body', async () => {
+    app.use((ctx) => {
+      ctx.status = 204;
+    });
+
+    const response = await sendRequest(
+      app,
+      createAwsV1Event() as unknown as Record<string, unknown>,
+      createAwsContext() as unknown as Record<string, unknown>,
+    );
+
+    expect(response.statusCode).toEqual(204);
+    expect(response.body).toEqual('');
+  });
+
+  it('should handle 500 error from middleware', async () => {
+    app.use(() => {
+      throw new Error('Internal server error');
+    });
+
+    const response = await sendRequest(
+      app,
+      createAwsV1Event() as unknown as Record<string, unknown>,
+      createAwsContext() as unknown as Record<string, unknown>,
+    );
+
+    expect(response.statusCode).toEqual(500);
+  });
+
+  it('should handle request with router', async () => {
+    const router = new Router();
+    router.get('/api/test', (ctx) => {
+      ctx.status = 200;
+      ctx.body = { route: 'test' };
+    });
+
+    app.use(router.routes());
+
+    const response = await sendRequest(
+      app,
+      createAwsV1Event({
+        httpMethod: 'GET',
+        path: '/api/test',
+      }) as unknown as Record<string, unknown>,
+      createAwsContext() as unknown as Record<string, unknown>,
+    );
+
+    expect(response.statusCode).toEqual(200);
+    expect(JSON.parse(response.body)).toEqual({ route: 'test' });
+  });
+
+  it('should handle 404 response', async () => {
+    app.use((ctx) => {
+      ctx.status = 404;
+      ctx.body = 'Not Found';
+    });
+
+    const response = await sendRequest(
+      app,
+      createAwsV1Event({
+        httpMethod: 'GET',
+        path: '/api/notexists',
+      }) as unknown as Record<string, unknown>,
+      createAwsContext() as unknown as Record<string, unknown>,
+    );
+
+    expect(response.statusCode).toEqual(404);
+  });
+});

--- a/tests/index-aws.spec.test.ts
+++ b/tests/index-aws.spec.test.ts
@@ -1,0 +1,312 @@
+import express, { Express, Request, Response } from 'express4';
+import bodyParser from 'body-parser';
+import { createAwsContext, createAwsV1Event, createAwsV2Event } from './fixtures/awsContext';
+import { sendRequest } from './fixtures/requestHelper';
+
+describe('AWS Lambda + API Gateway with Express 4.x', () => {
+  let app: Express;
+
+  beforeEach(() => {
+    app = express();
+  });
+
+  describe('API Gateway v1 (REST API)', () => {
+    it('basic middleware should set statusCode and default body', async () => {
+      app.use((req: Request, res: Response) => {
+        res.status(418).send(`I'm a teapot`);
+      });
+
+      const response = await sendRequest(
+        app,
+        createAwsV1Event() as unknown as Record<string, unknown>,
+        createAwsContext() as unknown as Record<string, unknown>,
+      );
+      expect(response.statusCode).toEqual(418);
+      expect(response.body).toEqual(`I'm a teapot`);
+    });
+
+    it('basic middleware should get json body', async () => {
+      app.use(bodyParser.json());
+      app.use((req: Request, res: Response) => {
+        res.status(200).send(req.body.hello);
+      });
+
+      const response = await sendRequest(
+        app,
+        createAwsV1Event({
+          httpMethod: 'POST',
+          body: JSON.stringify({ hello: 'world' }),
+          headers: { 'Content-Type': 'application/json' },
+        }) as unknown as Record<string, unknown>,
+        createAwsContext() as unknown as Record<string, unknown>,
+      );
+
+      expect(response.statusCode).toEqual(200);
+      expect(response.body).toEqual('world');
+    });
+
+    it('basic middleware should get query params', async () => {
+      app.use((req: Request, res: Response) => {
+        res.status(200).send(req.query.foo as string);
+      });
+
+      const response = await sendRequest(
+        app,
+        createAwsV1Event({
+          httpMethod: 'GET',
+          queryStringParameters: { foo: 'bar' },
+        }) as unknown as Record<string, unknown>,
+        createAwsContext() as unknown as Record<string, unknown>,
+      );
+      expect(response.statusCode).toEqual(200);
+      expect(response.body).toEqual('bar');
+    });
+
+    it('should match verbs', async () => {
+      app.get('/*', (req: Request, res: Response) => {
+        res.status(200).send('foo');
+      });
+      app.put('/*', (req: Request, res: Response) => {
+        res.status(201).send('bar');
+      });
+
+      const response = await sendRequest(
+        app,
+        createAwsV1Event({ httpMethod: 'PUT' }) as unknown as Record<string, unknown>,
+        createAwsContext() as unknown as Record<string, unknown>,
+      );
+
+      expect(response.statusCode).toEqual(201);
+      expect(response.body).toEqual('bar');
+    });
+
+    it('should handle DELETE method', async () => {
+      app.delete('/*', (req: Request, res: Response) => {
+        res.status(204).send('deleted');
+      });
+
+      const response = await sendRequest(
+        app,
+        createAwsV1Event({ httpMethod: 'DELETE' }) as unknown as Record<string, unknown>,
+        createAwsContext() as unknown as Record<string, unknown>,
+      );
+      expect(response.statusCode).toEqual(204);
+    });
+
+    it('should handle PATCH method', async () => {
+      app.patch('/*', (req: Request, res: Response) => {
+        res.status(200).send('patched');
+      });
+
+      const response = await sendRequest(
+        app,
+        createAwsV1Event({
+          httpMethod: 'PATCH',
+          body: JSON.stringify({ update: 'value' }),
+          headers: { 'Content-Type': 'application/json' },
+        }) as unknown as Record<string, unknown>,
+        createAwsContext() as unknown as Record<string, unknown>,
+      );
+      expect(response.statusCode).toEqual(200);
+      expect(response.body).toEqual('patched');
+    });
+
+    it('should handle custom headers in response', async () => {
+      app.use((req: Request, res: Response) => {
+        res.setHeader('X-Custom-Header', 'custom-value');
+        res.setHeader('X-Another', 'another-value');
+        res.status(200).send('ok');
+      });
+
+      const response = await sendRequest(
+        app,
+        createAwsV1Event() as unknown as Record<string, unknown>,
+        createAwsContext() as unknown as Record<string, unknown>,
+      );
+
+      expect(response.statusCode).toEqual(200);
+      expect(response.headers['x-custom-header']).toEqual('custom-value');
+      expect(response.headers['x-another']).toEqual('another-value');
+    });
+
+    it('should handle response with JSON', async () => {
+      app.use((req: Request, res: Response) => {
+        res.status(200).json({ message: 'hello', count: 42 });
+      });
+
+      const response = await sendRequest(
+        app,
+        createAwsV1Event() as unknown as Record<string, unknown>,
+        createAwsContext() as unknown as Record<string, unknown>,
+      );
+
+      expect(response.statusCode).toEqual(200);
+      expect(JSON.parse(response.body)).toEqual({ message: 'hello', count: 42 });
+    });
+
+    it('should handle empty response body', async () => {
+      app.use((req: Request, res: Response) => {
+        res.status(204).end();
+      });
+
+      const response = await sendRequest(
+        app,
+        createAwsV1Event() as unknown as Record<string, unknown>,
+        createAwsContext() as unknown as Record<string, unknown>,
+      );
+
+      expect(response.statusCode).toEqual(204);
+      expect(response.body).toEqual('');
+    });
+
+    it('should handle 500 error from middleware', async () => {
+      app.use(() => {
+        throw new Error('Internal server error');
+      });
+
+      const response = await sendRequest(
+        app,
+        createAwsV1Event() as unknown as Record<string, unknown>,
+        createAwsContext() as unknown as Record<string, unknown>,
+      );
+
+      expect(response.statusCode).toEqual(500);
+    });
+
+    it('should handle request with multiple query parameters', async () => {
+      app.use((req: Request, res: Response) => {
+        res.status(200).json(req.query);
+      });
+
+      const response = await sendRequest(
+        app,
+        createAwsV1Event({
+          httpMethod: 'GET',
+          queryStringParameters: {
+            foo: 'bar',
+            baz: 'qux',
+            num: '123',
+          },
+        }) as unknown as Record<string, unknown>,
+        createAwsContext() as unknown as Record<string, unknown>,
+      );
+
+      expect(response.statusCode).toEqual(200);
+      expect(JSON.parse(response.body)).toEqual({
+        foo: 'bar',
+        baz: 'qux',
+        num: '123',
+      });
+    });
+
+    it('should handle 404 response', async () => {
+      app.get('/api/exists', (req: Request, res: Response) => {
+        res.status(200).send('exists');
+      });
+
+      const response = await sendRequest(
+        app,
+        createAwsV1Event({
+          httpMethod: 'GET',
+          path: '/api/notexists',
+        }) as unknown as Record<string, unknown>,
+        createAwsContext() as unknown as Record<string, unknown>,
+      );
+
+      expect(response.statusCode).toEqual(404);
+    });
+  });
+
+  describe('API Gateway v2 (HTTP API)', () => {
+    it('should handle v2 event correctly', async () => {
+      app.use((req: Request, res: Response) => {
+        res.status(200).send('v2 success');
+      });
+
+      const response = await sendRequest(
+        app,
+        createAwsV2Event() as unknown as Record<string, unknown>,
+        createAwsContext() as unknown as Record<string, unknown>,
+      );
+
+      expect(response.statusCode).toEqual(200);
+      expect(response.body).toEqual('v2 success');
+    });
+
+    it('should handle v2 event with JSON body', async () => {
+      app.use(bodyParser.json());
+      app.use((req: Request, res: Response) => {
+        res.status(200).send(req.body.hello);
+      });
+
+      const response = await sendRequest(
+        app,
+        createAwsV2Event({
+          routeKey: 'POST /api/test',
+          rawPath: '/api/test',
+          body: JSON.stringify({ hello: 'world' }),
+          headers: { 'Content-Type': 'application/json' },
+        }) as unknown as Record<string, unknown>,
+        createAwsContext() as unknown as Record<string, unknown>,
+      );
+
+      expect(response.statusCode).toEqual(200);
+      expect(response.body).toEqual('world');
+    });
+
+    it('should handle v2 event with query parameters', async () => {
+      app.use((req: Request, res: Response) => {
+        res.status(200).send(req.query.foo as string);
+      });
+
+      const response = await sendRequest(
+        app,
+        createAwsV2Event({
+          routeKey: 'GET /api/test',
+          rawPath: '/api/test',
+          rawQueryString: 'foo=bar',
+          queryStringParameters: { foo: 'bar' },
+        }) as unknown as Record<string, unknown>,
+        createAwsContext() as unknown as Record<string, unknown>,
+      );
+
+      expect(response.statusCode).toEqual(200);
+      expect(response.body).toEqual('bar');
+    });
+
+    it('should handle v2 event with different verbs', async () => {
+      app.put('/*', (req: Request, res: Response) => {
+        res.status(200).send('put-ok');
+      });
+
+      const response = await sendRequest(
+        app,
+        createAwsV2Event({
+          routeKey: 'PUT /api/items',
+          rawPath: '/api/items',
+        }) as unknown as Record<string, unknown>,
+        createAwsContext() as unknown as Record<string, unknown>,
+      );
+
+      expect(response.statusCode).toEqual(200);
+      expect(response.body).toEqual('put-ok');
+    });
+  });
+
+  it('should return AWS response format', async () => {
+    app.use((req: Request, res: Response) => {
+      res.status(200).json({ provider: 'aws' });
+    });
+
+    const response = await sendRequest(
+      app,
+      createAwsV1Event() as unknown as Record<string, unknown>,
+      createAwsContext() as unknown as Record<string, unknown>,
+    );
+
+    expect(response).toHaveProperty('statusCode');
+    expect(response).toHaveProperty('body');
+    expect(response).toHaveProperty('headers');
+    expect(response).toHaveProperty('isBase64Encoded');
+  });
+});

--- a/tests/unit/providers/aws.test.ts
+++ b/tests/unit/providers/aws.test.ts
@@ -1,0 +1,584 @@
+import { AWSProvider } from '../../../src/providers/aws';
+import {
+  AwsApiGatewayV1Event,
+  AwsApiGatewayV2Event,
+  AwsLambdaContext,
+} from '../../../src/types/aws';
+import { createAwsV1Event, createAwsV2Event, createAwsContext } from '../../fixtures/awsContext';
+
+describe('AWSProvider', () => {
+  let provider: AWSProvider;
+
+  beforeEach(() => {
+    provider = new AWSProvider();
+  });
+
+  describe('name', () => {
+    it('should return "aws"', () => {
+      expect(provider.name).toBe('aws');
+    });
+  });
+
+  describe('normalizeEvent (v1 - REST API)', () => {
+    it('should normalize v1 API Gateway event to ServerlessEvent', () => {
+      const v1Event: AwsApiGatewayV1Event = {
+        path: '/api/users',
+        httpMethod: 'POST',
+        headers: { 'content-type': 'application/json' },
+        queryStringParameters: { page: '1' },
+        pathParameters: { id: '123' },
+        body: '{"name":"test"}',
+        isBase64Encoded: false,
+        requestContext: {
+          stage: 'dev',
+          requestId: 'req-abc',
+          identity: { sourceIp: '10.0.0.1' },
+        },
+      };
+
+      const rawEvent = Buffer.from(JSON.stringify(v1Event));
+      const result = provider.normalizeEvent(rawEvent);
+
+      expect(result.path).toBe('/api/users');
+      expect(result.httpMethod).toBe('POST');
+      expect(result.body).toBe('{"name":"test"}');
+      expect(result.headers).toEqual({ 'content-type': 'application/json' });
+      expect(result.queryParameters).toEqual({ page: '1' });
+      expect(result.pathParameters).toEqual({ id: '123' });
+      expect(result.isBase64Encoded).toBe(false);
+    });
+
+    it('should handle v1 event with no body', () => {
+      const v1Event = createAwsV1Event({
+        httpMethod: 'GET',
+        body: null,
+      });
+
+      const rawEvent = Buffer.from(JSON.stringify(v1Event));
+      const result = provider.normalizeEvent(rawEvent);
+
+      expect(result.body).toBeUndefined();
+    });
+
+    it('should handle v1 event without headers (use fallback)', () => {
+      const v1Event = createAwsV1Event({
+        headers: undefined as unknown as Record<string, string>,
+      });
+
+      const rawEvent = Buffer.from(JSON.stringify(v1Event));
+      const result = provider.normalizeEvent(rawEvent);
+
+      expect(result.headers).toEqual({});
+    });
+
+    it('should handle v1 event without queryStringParameters (use fallback)', () => {
+      const v1Event = createAwsV1Event({
+        queryStringParameters: undefined,
+      });
+
+      const rawEvent = Buffer.from(JSON.stringify(v1Event));
+      const result = provider.normalizeEvent(rawEvent);
+
+      expect(result.queryParameters).toEqual({});
+    });
+
+    it('should handle v1 event without pathParameters (use fallback)', () => {
+      const v1Event = createAwsV1Event({
+        pathParameters: undefined,
+      });
+
+      const rawEvent = Buffer.from(JSON.stringify(v1Event));
+      const result = provider.normalizeEvent(rawEvent);
+
+      expect(result.pathParameters).toEqual({});
+    });
+
+    it('should handle v1 event without isBase64Encoded (use fallback)', () => {
+      const v1Event = {
+        path: '/test',
+        httpMethod: 'GET',
+        headers: {},
+        body: null,
+        requestContext: {
+          stage: 'dev',
+          requestId: 'req-abc',
+          identity: {},
+        },
+      };
+
+      const rawEvent = Buffer.from(JSON.stringify(v1Event));
+      const result = provider.normalizeEvent(rawEvent);
+
+      expect(result.isBase64Encoded).toBe(false);
+    });
+
+    it('should handle v1 event as plain object (not Buffer)', () => {
+      const v1Event = createAwsV1Event({
+        httpMethod: 'DELETE',
+        path: '/api/items/1',
+      });
+
+      const result = provider.normalizeEvent(v1Event as unknown as Buffer);
+
+      expect(result.path).toBe('/api/items/1');
+      expect(result.httpMethod).toBe('DELETE');
+    });
+
+    it('should handle v1 event as string', () => {
+      const v1Event = createAwsV1Event({
+        httpMethod: 'PUT',
+        path: '/api/items',
+      });
+
+      const rawEvent = JSON.stringify(v1Event);
+      const result = provider.normalizeEvent(rawEvent as unknown as Buffer);
+
+      expect(result.path).toBe('/api/items');
+      expect(result.httpMethod).toBe('PUT');
+    });
+
+    it('should handle v1 base64 encoded body', () => {
+      const originalBody = 'hello world';
+      const base64Body = Buffer.from(originalBody).toString('base64');
+      const v1Event = createAwsV1Event({
+        httpMethod: 'POST',
+        body: base64Body,
+        isBase64Encoded: true,
+      });
+
+      const rawEvent = Buffer.from(JSON.stringify(v1Event));
+      const result = provider.normalizeEvent(rawEvent);
+
+      expect(result.isBase64Encoded).toBe(true);
+      expect(result.body).toBe(base64Body);
+    });
+  });
+
+  describe('normalizeEvent (v2 - HTTP API)', () => {
+    it('should normalize v2 HTTP API event to ServerlessEvent', () => {
+      const v2Event: AwsApiGatewayV2Event = {
+        version: '2.0',
+        routeKey: 'POST /api/users',
+        rawPath: '/api/users',
+        rawQueryString: 'page=1',
+        headers: { 'content-type': 'application/json' },
+        queryStringParameters: { page: '1' },
+        pathParameters: { id: '123' },
+        body: '{"name":"test"}',
+        isBase64Encoded: false,
+        requestContext: {
+          stage: '$default',
+          requestId: 'req-abc',
+          time: '27/Jul/2026:12:00:00 +0000',
+          timeEpoch: 1722072000000,
+          http: {
+            method: 'POST',
+            path: '/api/users',
+            protocol: 'HTTP/1.1',
+            sourceIp: '10.0.0.1',
+            userAgent: 'test-agent',
+          },
+        },
+      };
+
+      const rawEvent = Buffer.from(JSON.stringify(v2Event));
+      const result = provider.normalizeEvent(rawEvent);
+
+      expect(result.path).toBe('/api/users');
+      expect(result.httpMethod).toBe('POST');
+      expect(result.body).toBe('{"name":"test"}');
+      expect(result.headers).toEqual({ 'content-type': 'application/json' });
+      expect(result.queryParameters).toEqual({ page: '1' });
+      expect(result.pathParameters).toEqual({ id: '123' });
+      expect(result.isBase64Encoded).toBe(false);
+    });
+
+    it('should extract HTTP method from routeKey in v2 events', () => {
+      const v2Event = createAwsV2Event({
+        routeKey: 'GET /api/users',
+        rawPath: '/api/users',
+      });
+
+      const rawEvent = Buffer.from(JSON.stringify(v2Event));
+      const result = provider.normalizeEvent(rawEvent);
+
+      expect(result.httpMethod).toBe('GET');
+    });
+
+    it('should handle v2 event with queryStringParameters from rawQueryString fallback', () => {
+      const v2Event = createAwsV2Event({
+        rawQueryString: 'foo=bar&baz=qux',
+        queryStringParameters: undefined,
+      });
+
+      const rawEvent = Buffer.from(JSON.stringify(v2Event));
+      const result = provider.normalizeEvent(rawEvent);
+
+      expect(result.queryParameters).toEqual({ foo: 'bar', baz: 'qux' });
+    });
+
+    it('should handle v2 event with no body', () => {
+      const v2Event = createAwsV2Event({
+        body: null,
+      });
+
+      const rawEvent = Buffer.from(JSON.stringify(v2Event));
+      const result = provider.normalizeEvent(rawEvent);
+
+      expect(result.body).toBeUndefined();
+    });
+
+    it('should handle v2 event without headers (use fallback)', () => {
+      const v2Event = createAwsV2Event({
+        headers: undefined as unknown as Record<string, string>,
+      });
+
+      const rawEvent = Buffer.from(JSON.stringify(v2Event));
+      const result = provider.normalizeEvent(rawEvent);
+
+      expect(result.headers).toEqual({});
+    });
+
+    it('should handle v2 event without pathParameters (use fallback)', () => {
+      const v2Event = createAwsV2Event({
+        pathParameters: undefined,
+      });
+
+      const rawEvent = Buffer.from(JSON.stringify(v2Event));
+      const result = provider.normalizeEvent(rawEvent);
+
+      expect(result.pathParameters).toEqual({});
+    });
+
+    it('should handle v2 event without isBase64Encoded (use fallback)', () => {
+      const v2Event = {
+        version: '2.0',
+        routeKey: 'GET /test',
+        rawPath: '/test',
+        rawQueryString: '',
+        headers: {},
+        body: null,
+        requestContext: {
+          stage: '$default',
+          requestId: 'req-abc',
+          time: '27/Jul/2026:12:00:00 +0000',
+          timeEpoch: 1722072000000,
+          http: {
+            method: 'GET',
+            path: '/test',
+            protocol: 'HTTP/1.1',
+            sourceIp: '10.0.0.1',
+            userAgent: 'test-agent',
+          },
+        },
+      };
+
+      const rawEvent = Buffer.from(JSON.stringify(v2Event));
+      const result = provider.normalizeEvent(rawEvent);
+
+      expect(result.isBase64Encoded).toBe(false);
+    });
+
+    it('should handle v2 event with base64 encoded body', () => {
+      const originalBody = 'hello world';
+      const base64Body = Buffer.from(originalBody).toString('base64');
+      const v2Event = createAwsV2Event({
+        body: base64Body,
+        isBase64Encoded: true,
+      });
+
+      const rawEvent = Buffer.from(JSON.stringify(v2Event));
+      const result = provider.normalizeEvent(rawEvent);
+
+      expect(result.isBase64Encoded).toBe(true);
+      expect(result.body).toBe(base64Body);
+    });
+
+    it('should handle v2 event with DELETE method from routeKey', () => {
+      const v2Event = createAwsV2Event({
+        routeKey: 'DELETE /api/items/1',
+        rawPath: '/api/items/1',
+      });
+
+      const rawEvent = Buffer.from(JSON.stringify(v2Event));
+      const result = provider.normalizeEvent(rawEvent);
+
+      expect(result.httpMethod).toBe('DELETE');
+    });
+
+    it('should handle v2 event with PATCH method from routeKey', () => {
+      const v2Event = createAwsV2Event({
+        routeKey: 'PATCH /api/items/1',
+        rawPath: '/api/items/1',
+      });
+
+      const rawEvent = Buffer.from(JSON.stringify(v2Event));
+      const result = provider.normalizeEvent(rawEvent);
+
+      expect(result.httpMethod).toBe('PATCH');
+    });
+  });
+
+  describe('createRequest', () => {
+    it('should create ServerlessRequest from normalized event', () => {
+      const event = {
+        path: '/test',
+        httpMethod: 'POST',
+        headers: { 'content-type': 'application/json' },
+        queryParameters: { foo: 'bar' },
+        pathParameters: {},
+        body: '{"key":"value"}',
+        isBase64Encoded: false,
+      };
+
+      const { request, isBase64Encoded } = provider.createRequest(event);
+
+      expect(request.method).toBe('POST');
+      expect(request.url).toBe('/test?foo=bar');
+      expect(request.headers['content-type']).toBe('application/json');
+      expect(isBase64Encoded).toBe(false);
+    });
+
+    it('should create request with base64 encoded body', () => {
+      const originalBody = 'hello world';
+      const base64Body = Buffer.from(originalBody).toString('base64');
+      const event = {
+        path: '/test',
+        httpMethod: 'POST',
+        headers: {},
+        queryParameters: {},
+        pathParameters: {},
+        body: base64Body,
+        isBase64Encoded: true,
+      };
+
+      const { request, isBase64Encoded } = provider.createRequest(event);
+
+      expect(isBase64Encoded).toBe(true);
+      expect(request.body?.toString()).toBe(originalBody);
+    });
+
+    it('should handle query parameters in URL', () => {
+      const event = {
+        path: '/search',
+        httpMethod: 'GET',
+        headers: {},
+        queryParameters: { q: 'test', page: '1' },
+        pathParameters: {},
+        body: undefined,
+        isBase64Encoded: false,
+      };
+
+      const { request } = provider.createRequest(event);
+
+      expect(request.url).toContain('q=test');
+      expect(request.url).toContain('page=1');
+    });
+
+    it('should handle Buffer body', () => {
+      const bufferBody = Buffer.from('buffer content');
+      const event = {
+        path: '/test',
+        httpMethod: 'POST',
+        headers: {},
+        queryParameters: {},
+        pathParameters: {},
+        body: bufferBody,
+        isBase64Encoded: false,
+      };
+
+      const { request } = provider.createRequest(event);
+
+      expect(request.body).toBe(bufferBody);
+    });
+
+    it('should handle object body', () => {
+      const event = {
+        path: '/test',
+        httpMethod: 'POST',
+        headers: {},
+        queryParameters: {},
+        pathParameters: {},
+        body: { key: 'value', nested: { foo: 'bar' } },
+        isBase64Encoded: false,
+      };
+
+      const { request } = provider.createRequest(event);
+
+      expect(JSON.parse(request.body?.toString() || '{}')).toEqual({
+        key: 'value',
+        nested: { foo: 'bar' },
+      });
+    });
+
+    it('should handle null headers', () => {
+      const event = {
+        path: '/test',
+        httpMethod: 'GET',
+        headers: null as unknown as Record<string, string>,
+        queryParameters: {},
+        pathParameters: {},
+        body: undefined,
+        isBase64Encoded: false,
+      };
+
+      const { request } = provider.createRequest(event);
+
+      expect(request.headers).toEqual({ 'content-length': '0' });
+    });
+
+    it('should throw error for unexpected body type', () => {
+      const event = {
+        path: '/test',
+        httpMethod: 'POST',
+        headers: {},
+        queryParameters: {},
+        pathParameters: {},
+        body: 123,
+        isBase64Encoded: false,
+      };
+
+      expect(() => provider.createRequest(event)).toThrow('Unexpected event.body type: number');
+    });
+
+    it('should handle event without query parameters', () => {
+      const event = {
+        path: '/test',
+        httpMethod: 'GET',
+        headers: {},
+        queryParameters: {},
+        pathParameters: {},
+        body: undefined,
+        isBase64Encoded: false,
+      };
+
+      const { request } = provider.createRequest(event);
+
+      expect(request.url).toBe('/test');
+    });
+  });
+
+  describe('formatResponse', () => {
+    it('should format response correctly', () => {
+      const response = {
+        statusCode: 200,
+        body: '{"message":"success"}',
+        headers: { 'Content-Type': 'application/json' },
+        isBase64Encoded: false,
+      };
+
+      const result = provider.formatResponse(response);
+
+      expect(result.statusCode).toBe(200);
+      expect(result.body).toBe('{"message":"success"}');
+      expect(result.headers).toEqual({ 'Content-Type': 'application/json' });
+      expect(result.isBase64Encoded).toBe(false);
+    });
+
+    it('should handle error responses', () => {
+      const response = {
+        statusCode: 500,
+        body: 'Internal Server Error',
+        headers: {},
+        isBase64Encoded: false,
+      };
+
+      const result = provider.formatResponse(response);
+
+      expect(result.statusCode).toBe(500);
+      expect(result.body).toBe('Internal Server Error');
+    });
+
+    it('should include multiValueHeaders when present', () => {
+      const response = {
+        statusCode: 200,
+        body: 'ok',
+        headers: { 'content-type': 'text/plain' },
+        isBase64Encoded: false,
+        multiValueHeaders: {
+          'set-cookie': ['cookie1=val1', 'cookie2=val2'],
+        },
+      };
+
+      const result = provider.formatResponse(response);
+
+      expect(result.multiValueHeaders).toEqual({
+        'set-cookie': ['cookie1=val1', 'cookie2=val2'],
+      });
+    });
+  });
+
+  describe('detect', () => {
+    it('should detect AWS context by awsRequestId', () => {
+      const rawEvent = Buffer.from(JSON.stringify(createAwsV1Event()));
+      const context = createAwsContext();
+
+      expect(provider.detect(rawEvent, context)).toBe(true);
+    });
+
+    it('should detect AWS context by invokedFunctionArn', () => {
+      const rawEvent = Buffer.from(JSON.stringify(createAwsV1Event()));
+      const context = createAwsContext({
+        awsRequestId: undefined as unknown as string,
+      });
+
+      expect(provider.detect(rawEvent, context)).toBe(true);
+    });
+
+    it('should detect AWS context by functionName', () => {
+      const rawEvent = Buffer.from(JSON.stringify(createAwsV1Event()));
+      const context = createAwsContext({
+        awsRequestId: undefined as unknown as string,
+        invokedFunctionArn: undefined as unknown as string,
+      });
+
+      expect(provider.detect(rawEvent, context)).toBe(true);
+    });
+
+    it('should not detect non-AWS context (empty object)', () => {
+      const rawEvent = Buffer.from(JSON.stringify({}));
+      const context = {};
+
+      expect(provider.detect(rawEvent, context as unknown as AwsLambdaContext)).toBe(false);
+    });
+
+    it('should not detect Aliyun context', () => {
+      const rawEvent = Buffer.from(JSON.stringify({}));
+      const context = {
+        requestId: 'test-id',
+        region: 'cn-hangzhou',
+        accountId: '123456',
+        credentials: { accessKeyId: 'key', accessKeySecret: 'secret', securityToken: '' },
+        service: { name: 'test-service' },
+        tracing: { spanContext: 'span' },
+        logger: { log: () => {} },
+      };
+
+      expect(provider.detect(rawEvent, context as unknown as AwsLambdaContext)).toBe(false);
+    });
+
+    it('should not detect Tencent context', () => {
+      const rawEvent = Buffer.from(JSON.stringify({}));
+      const context = {
+        tencentcloud_region: 'ap-guangzhou',
+        namespace: 'default',
+        tencentcloud_appid: '123456',
+      };
+
+      expect(provider.detect(rawEvent, context as unknown as AwsLambdaContext)).toBe(false);
+    });
+
+    it('should not detect Volcengine context', () => {
+      const rawEvent = Buffer.from(JSON.stringify({}));
+      const context = {
+        requestId: 'test-id',
+        region: 'cn-beijing',
+        accountId: '123456',
+        credentials: { accessKeyId: 'key', accessKeySecret: 'secret', securityToken: 'token' },
+        function: { memoryMb: 128 },
+      };
+
+      expect(provider.detect(rawEvent, context as unknown as AwsLambdaContext)).toBe(false);
+    });
+  });
+});

--- a/tests/unit/providers/index.test.ts
+++ b/tests/unit/providers/index.test.ts
@@ -5,10 +5,12 @@ import {
   AliyunProvider,
   TencentProvider,
   VolcengineProvider,
+  AWSProvider,
 } from '../../../src/providers';
 import { defaultContext } from '../../fixtures/fcContext';
 import { createTencentContext, createTencentEvent } from '../../fixtures/tencentContext';
 import { createVolcengineContext, createVolcengineEvent } from '../../fixtures/volcengineContext';
+import { createAwsV1Event, createAwsContext } from '../../fixtures/awsContext';
 import { AliyunApiGatewayContext } from '../../../src/types/aliyun';
 import { VolcengineVefaasContext } from '../../../src/types/volcengine';
 
@@ -29,8 +31,13 @@ describe('providers/index', () => {
       expect(provider).toBeInstanceOf(VolcengineProvider);
     });
 
+    it('should return AWSProvider for "aws"', () => {
+      const provider = getProvider('aws');
+      expect(provider).toBeInstanceOf(AWSProvider);
+    });
+
     it('should return undefined for unknown provider', () => {
-      const provider = getProvider('unknown' as 'aliyun' | 'tencent' | 'volcengine');
+      const provider = getProvider('unknown' as 'aliyun' | 'tencent' | 'volcengine' | 'aws');
       expect(provider).toBeUndefined();
     });
   });
@@ -56,6 +63,13 @@ describe('providers/index', () => {
       expect(provider?.name).toBe('volcengine');
     });
 
+    it('should detect AWS provider', () => {
+      const rawEvent = Buffer.from(JSON.stringify(createAwsV1Event()));
+      const context = createAwsContext();
+      const provider = detectProvider(rawEvent, context);
+      expect(provider?.name).toBe('aws');
+    });
+
     it('should return undefined when no provider matches', () => {
       const rawEvent = Buffer.from(JSON.stringify({}));
       const context = { unknown: true };
@@ -67,10 +81,11 @@ describe('providers/index', () => {
   describe('getAllProviders', () => {
     it('should return map of all providers', () => {
       const providers = getAllProviders();
-      expect(providers.size).toBe(3);
+      expect(providers.size).toBe(4);
       expect(providers.has('aliyun')).toBe(true);
       expect(providers.has('tencent')).toBe(true);
       expect(providers.has('volcengine')).toBe(true);
+      expect(providers.has('aws')).toBe(true);
     });
   });
 });


### PR DESCRIPTION
## Summary

Adds support for AWS Lambda + API Gateway (both REST API v1 and HTTP API v2 event formats). After this PR, the adapter supports all major cloud providers: Alibaba Cloud (Aliyun), Tencent Cloud, Volcengine, and AWS.

## Changes

### New files
- **`src/types/aws.ts`** — TypeScript types for `AwsApiGatewayV1Event`, `AwsApiGatewayV2Event`, `AwsLambdaContext`, `AwsResponse`
- **`src/providers/aws.ts`** — `AWSProvider` implementation with:
  - `normalizeEvent`: auto-detects v1 vs v2 events by checking `event.version === "2.0"`
  - `formatResponse`: returns AWS-compatible response format
  - `detect`: identifies AWS by `awsRequestId`, `invokedFunctionArn`, or `functionName`
- **`tests/fixtures/awsContext.ts`** — Test fixtures with factory functions
- **`tests/unit/providers/aws.test.ts`** — 47 unit tests covering all methods and edge cases
- **`tests/index-aws.spec.test.ts`** — Express 4x integration tests (v1 + v2)
- **`tests/index-aws-koa-2x.spec.test.ts`** — Koa 2x integration tests
- **`tests/index-aws-hono.spec.test.ts`** — Hono integration tests

### Modified files
- **`src/types/index.ts`** — Added `"aws"` to `CloudProvider`, extended `ProviderContext`/`ProviderEvent` unions
- **`src/providers/index.ts`** — Registered `AWSProvider`
- **`tests/unit/providers/index.test.ts`** — Added AWS registry tests
- **`README.md`** — Added AWS to supported providers table

## Event Format Support

| Type | Field Mapping |
|------|---------------|
| **v1 (REST API)** | `event.path`, `event.httpMethod`, `event.queryStringParameters`, `event.headers`, `event.body`, `event.isBase64Encoded` |
| **v2 (HTTP API)** | `event.rawPath`, `event.routeKey → method extraction`, `event.queryStringParameters`, `event.headers`, `event.body`, `event.isBase64Encoded` |

## Detection Strategy
AWS Lambda context is identified by checking for `awsRequestId`, `invokedFunctionArn`, or `functionName` — fields that are unique to AWS and absent in Aliyun, Tencent, or Volcengine contexts.

## Verification
- **30 test suites, 407 tests** — all pass
- **Coverage**: 96.92% statements, 87.95% branches, 97.01% functions, 97.36% lines
- **Build**: `tsc --build` passes with 0 errors
- **Manual QA**: All scenarios (v1 normalization, v2 normalization, detection, formatResponse, full Express pipeline) verified

Closes #17