### PR TITLE
feat: Tencent SCF Function URL event format support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,11 @@ Adapter for web frameworks (Express, Koa, Hono) to run on serverless platforms a
 | Provider               | Service                         | Status       | Trigger Type |
 | ---------------------- | ------------------------------- | ------------ | ------------ |
 | Alibaba Cloud (Aliyun) | Function Compute                | ✅ Supported | API Gateway  |
-| Tencent Cloud          | Serverless Cloud Function (SCF) | ✅ Supported | API Gateway  |
+| Tencent Cloud          | Serverless Cloud Function (SCF) | ✅ Supported | API Gateway + Function URL  |
 | Volcengine             | veFaaS (函数服务)               | ✅ Supported | API Gateway  |
 | AWS                    | Lambda + API Gateway            | ✅ Supported | API Gateway (REST API v1 & HTTP API v2) |
+
+> **Note**: Tencent SCF supports both the legacy API Gateway trigger and the Function URL (函数 URL) event-function format. Web 函数 (Web functions, raw HTTP on port 9000) mode needs no adapter and is out of scope.
 
 ## Supported Frameworks
 

--- a/src/providers/tencent.ts
+++ b/src/providers/tencent.ts
@@ -9,14 +9,45 @@ import {
   ProviderEvent,
 } from '../types';
 
+/**
+ * Discriminates the Function URL (函数 URL) event-function format from the legacy
+ * API Gateway trigger format via negative exclusion: queryStringParameters and
+ * requestContext are always present on legacy events and never on Function URL events.
+ * `== null` tolerates tooling-injected `null` for absent fields.
+ */
+const isFunctionUrlEvent = (raw: Record<string, unknown>): boolean =>
+  raw.queryStringParameters == null && raw.requestContext == null;
+
 export class TencentProvider extends BaseProvider {
   readonly name = 'tencent' as const;
 
-  normalizeEvent(rawEvent: ProviderEvent): ServerlessEvent {
-    const tencentEvent = JSON.parse(
-      Buffer.from(rawEvent as Buffer).toString(),
-    ) as TencentApiGatewayEvent;
+  /**
+   * Invocation format detected in normalizeEvent and consumed in formatResponse.
+   * Safe as instance state: Tencent SCF handles one invocation per instance at a time
+   * (freeze/thaw; concurrency spawns separate instances), and the provider is resolved
+   * per handler call (src/index.ts). The registry in src/providers/index.ts is a shared
+   * singleton, but this flag is always overwritten before it is read within an invocation.
+   */
+  private isFunctionUrlInvocation = false;
 
+  normalizeEvent(rawEvent: ProviderEvent): ServerlessEvent {
+    const raw = JSON.parse(Buffer.from(rawEvent as Buffer).toString()) as Record<string, unknown>;
+
+    if (isFunctionUrlEvent(raw)) {
+      this.isFunctionUrlInvocation = true;
+      return {
+        path: (raw.path as string) ?? '/',
+        httpMethod: raw.httpMethod as string,
+        headers: (raw.headers as Record<string, string>) ?? {},
+        queryParameters: (raw.queryString as Record<string, string>) ?? {},
+        pathParameters: {},
+        body: raw.body as string,
+        isBase64Encoded: false,
+      };
+    }
+
+    const tencentEvent = raw as unknown as TencentApiGatewayEvent;
+    this.isFunctionUrlInvocation = false;
     return {
       path: tencentEvent.path,
       httpMethod: tencentEvent.httpMethod,
@@ -29,6 +60,16 @@ export class TencentProvider extends BaseProvider {
   }
 
   formatResponse(response: ServerlessResponse): TencentScfResponse {
+    if (this.isFunctionUrlInvocation) {
+      // Function URL documents only { statusCode, headers, body } — isBase64Encoded
+      // and multiValueHeaders are not part of the contract and must be stripped.
+      return {
+        statusCode: response.statusCode,
+        headers: response.headers,
+        body: response.body,
+      };
+    }
+
     return {
       isBase64Encoded: response.isBase64Encoded,
       statusCode: response.statusCode,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,6 +4,7 @@ import Application from 'koa';
 import { AliyunApiGatewayContext, AliyunEvent, AliyunResponse } from './aliyun';
 import {
   TencentApiGatewayEvent,
+  TencentFunctionUrlEvent,
   TencentScfContext,
   TencentScfResponse,
   TencentEvent,
@@ -28,6 +29,7 @@ import {
 export { AliyunApiGatewayContext, AliyunEvent, AliyunResponse };
 export {
   TencentApiGatewayEvent,
+  TencentFunctionUrlEvent,
   TencentScfContext,
   TencentScfResponse,
   TencentEvent,

--- a/src/types/tencent.ts
+++ b/src/types/tencent.ts
@@ -28,6 +28,20 @@ export interface TencentApiGatewayEvent {
 }
 
 /**
+ * Tencent Cloud SCF Function URL (函数 URL) Event for Event Functions
+ * Compatible with the API Gateway protocol minus requestContext, pathParameters,
+ * queryStringParameters, headerParameters, isBase64Encoded. Query params arrive in `queryString`.
+ * @see https://intl.cloud.tencent.com/document/product/583/69491
+ */
+export interface TencentFunctionUrlEvent {
+  body?: string | null;
+  headers?: Record<string, string> | null;
+  httpMethod: string;
+  path?: string | null;
+  queryString?: Record<string, string> | null;
+}
+
+/**
  * Tencent Cloud SCF Context Object
  * @see https://www.tencentcloud.com/document/product/583/11060
  */
@@ -52,7 +66,7 @@ export interface TencentScfContext {
  * @see https://www.tencentcloud.com/document/product/583/12513
  */
 export interface TencentScfResponse {
-  isBase64Encoded: boolean;
+  isBase64Encoded?: boolean;
   statusCode: number;
   headers: IncomingHttpHeaders;
   body: string;

--- a/tests/fixtures/tencentContext.ts
+++ b/tests/fixtures/tencentContext.ts
@@ -1,4 +1,8 @@
-import { TencentScfContext, TencentApiGatewayEvent } from '../../src/types/tencent';
+import {
+  TencentScfContext,
+  TencentApiGatewayEvent,
+  TencentFunctionUrlEvent,
+} from '../../src/types/tencent';
 
 export const defaultTencentContext: TencentScfContext = {
   callbackWaitsForEmptyEventLoop: true,
@@ -40,6 +44,23 @@ export const defaultTencentApiGatewayEvent: TencentApiGatewayEvent = {
   headerParameters: {},
   stageVariables: {},
 };
+
+export const defaultTencentFunctionUrlEvent: TencentFunctionUrlEvent = {
+  httpMethod: 'GET',
+  path: '/api/test',
+  body: '',
+  headers: {
+    'Content-Type': 'application/json',
+  },
+  queryString: {},
+};
+
+export const createTencentFunctionUrlEvent = (
+  overrides: Partial<TencentFunctionUrlEvent> = {},
+): TencentFunctionUrlEvent => ({
+  ...defaultTencentFunctionUrlEvent,
+  ...overrides,
+});
 
 export const createTencentEvent = (
   overrides: Partial<TencentApiGatewayEvent> = {},

--- a/tests/index-tencent-function-url.spec.test.ts
+++ b/tests/index-tencent-function-url.spec.test.ts
@@ -1,0 +1,118 @@
+import { Hono } from 'hono';
+import { createTencentContext, createTencentFunctionUrlEvent } from './fixtures/tencentContext';
+import { sendRequest } from './fixtures/requestHelper';
+
+describe('Tencent SCF Function URL with Hono', () => {
+  let app: Hono;
+
+  beforeEach(() => {
+    app = new Hono();
+  });
+
+  it('happy path: GET should return JSON response', async () => {
+    app.get('/*', (c) => c.json({ ok: true }));
+
+    const response = await sendRequest(
+      app,
+      createTencentFunctionUrlEvent() as unknown as Record<string, unknown>,
+      createTencentContext() as unknown as Record<string, unknown>,
+    );
+
+    expect(response.statusCode).toEqual(200);
+    expect(JSON.parse(response.body)).toEqual({ ok: true });
+  });
+
+  it('Query params: GET should echo query parameters from queryString', async () => {
+    app.get('/*', (c) => c.json(c.req.query()));
+
+    const response = await sendRequest(
+      app,
+      createTencentFunctionUrlEvent({
+        queryString: { a: '1', b: 'hello world' },
+      }) as unknown as Record<string, unknown>,
+      createTencentContext() as unknown as Record<string, unknown>,
+    );
+
+    expect(response.statusCode).toEqual(200);
+    expect(JSON.parse(response.body)).toEqual({ a: '1', b: 'hello world' });
+  });
+
+  it('JSON body: POST should echo body back', async () => {
+    app.post('/*', async (c) => {
+      const body = await c.req.json();
+      return c.json(body);
+    });
+
+    const response = await sendRequest(
+      app,
+      createTencentFunctionUrlEvent({
+        httpMethod: 'POST',
+        body: JSON.stringify({ hello: 'world' }),
+        headers: { 'Content-Type': 'application/json' },
+      }) as unknown as Record<string, unknown>,
+      createTencentContext() as unknown as Record<string, unknown>,
+    );
+
+    expect(response.statusCode).toEqual(200);
+    expect(JSON.parse(response.body)).toEqual({ hello: 'world' });
+  });
+
+  it('Custom headers: GET should return custom header', async () => {
+    app.get('/*', (c) => {
+      c.header('X-Custom', 'value');
+      return c.text('ok');
+    });
+
+    const response = await sendRequest(
+      app,
+      createTencentFunctionUrlEvent() as unknown as Record<string, unknown>,
+      createTencentContext() as unknown as Record<string, unknown>,
+    );
+
+    expect(response.statusCode).toEqual(200);
+    expect(response.body).toEqual('ok');
+    expect(response.headers['x-custom']).toEqual('value');
+  });
+
+  it('404: unmatched route should return 404', async () => {
+    app.get('/api/exists', (c) => c.text('exists'));
+
+    const response = await sendRequest(
+      app,
+      createTencentFunctionUrlEvent({
+        path: '/api/notexists',
+      }) as unknown as Record<string, unknown>,
+      createTencentContext() as unknown as Record<string, unknown>,
+    );
+
+    expect(response.statusCode).toEqual(404);
+  });
+
+  it('Function URL response should NOT include isBase64Encoded or multiValueHeaders', async () => {
+    app.get('/*', (c) => c.json({ provider: 'tencent' }));
+
+    const response = await sendRequest(
+      app,
+      createTencentFunctionUrlEvent() as unknown as Record<string, unknown>,
+      createTencentContext() as unknown as Record<string, unknown>,
+    );
+
+    expect(response.statusCode).toEqual(200);
+    expect(response).not.toHaveProperty('isBase64Encoded');
+    expect(response).not.toHaveProperty('multiValueHeaders');
+  });
+
+  it('500 error: route that throws should return 500', async () => {
+    app.get('/*', () => {
+      throw new Error('boom');
+    });
+
+    const response = await sendRequest(
+      app,
+      createTencentFunctionUrlEvent() as unknown as Record<string, unknown>,
+      createTencentContext() as unknown as Record<string, unknown>,
+    );
+
+    expect(response.statusCode).toEqual(500);
+  });
+});

--- a/tests/unit/providers/tencent.test.ts
+++ b/tests/unit/providers/tencent.test.ts
@@ -1,7 +1,11 @@
 import { TencentProvider } from '../../../src/providers/tencent';
 import { TencentApiGatewayEvent } from '../../../src/types/tencent';
 import { TencentScfContext } from '../../../src/types/tencent';
-import { createTencentEvent, createTencentContext } from '../../fixtures/tencentContext';
+import {
+  createTencentEvent,
+  createTencentContext,
+  createTencentFunctionUrlEvent,
+} from '../../fixtures/tencentContext';
 
 describe('TencentProvider', () => {
   let provider: TencentProvider;
@@ -93,6 +97,120 @@ describe('TencentProvider', () => {
       const result = provider.normalizeEvent(rawEvent);
 
       expect(result.pathParameters).toEqual({});
+    });
+  });
+
+  describe('Function URL event', () => {
+    it('should map queryString to queryParameters for Function URL event', () => {
+      const rawEvent = Buffer.from(
+        JSON.stringify(
+          createTencentFunctionUrlEvent({
+            httpMethod: 'POST',
+            path: '/api/users',
+            body: '{"name":"test"}',
+            headers: { 'content-type': 'application/json' },
+            queryString: { a: '1', b: 'hello world' },
+          }),
+        ),
+      );
+
+      const result = provider.normalizeEvent(rawEvent);
+
+      expect(result.path).toBe('/api/users');
+      expect(result.httpMethod).toBe('POST');
+      expect(result.body).toBe('{"name":"test"}');
+      expect(result.headers).toEqual({ 'content-type': 'application/json' });
+      expect(result.queryParameters).toEqual({ a: '1', b: 'hello world' });
+      expect(result.pathParameters).toEqual({});
+      expect(result.isBase64Encoded).toBe(false);
+    });
+
+    it('should treat null-injected legacy fields as Function URL event', () => {
+      const rawEvent = Buffer.from(
+        JSON.stringify({
+          body: '{"a":1}',
+          headers: { 'content-type': 'application/json' },
+          httpMethod: 'POST',
+          path: '/',
+          queryString: { a: '1' },
+          queryStringParameters: null,
+          requestContext: null,
+        }),
+      );
+
+      const result = provider.normalizeEvent(rawEvent);
+
+      expect(result.queryParameters).toEqual({ a: '1' });
+    });
+
+    it('should handle null headers and null body for Function URL event', () => {
+      const rawEvent = Buffer.from(
+        JSON.stringify(createTencentFunctionUrlEvent({ headers: null, body: null })),
+      );
+
+      const result = provider.normalizeEvent(rawEvent);
+
+      expect(result.headers).toEqual({});
+      expect(result.body).toBeNull();
+    });
+
+    it('should default queryParameters to {} when queryString absent for Function URL', () => {
+      const rawEvent = Buffer.from(
+        JSON.stringify(createTencentFunctionUrlEvent({ queryString: undefined })),
+      );
+
+      const result = provider.normalizeEvent(rawEvent);
+
+      expect(result.queryParameters).toEqual({});
+    });
+
+    it('should default path to / when missing for Function URL event', () => {
+      const rawEvent = Buffer.from(
+        JSON.stringify(createTencentFunctionUrlEvent({ path: undefined })),
+      );
+
+      const result = provider.normalizeEvent(rawEvent);
+
+      expect(result.path).toBe('/');
+    });
+
+    it('should strip isBase64Encoded and multiValueHeaders for Function URL', () => {
+      provider.normalizeEvent(Buffer.from(JSON.stringify(createTencentFunctionUrlEvent())));
+
+      const result = provider.formatResponse({
+        statusCode: 201,
+        body: '{"message":"Hello"}',
+        headers: { 'Content-Type': 'application/json' },
+        isBase64Encoded: false,
+        multiValueHeaders: { 'set-cookie': ['a=1'] },
+      });
+
+      expect(result.statusCode).toBe(201);
+      expect(result.body).toBe('{"message":"Hello"}');
+      expect(result.headers).toEqual({ 'Content-Type': 'application/json' });
+      expect(result).not.toHaveProperty('isBase64Encoded');
+      expect(result).not.toHaveProperty('multiValueHeaders');
+    });
+
+    it('should strip isBase64Encoded even for binary response in Function URL', () => {
+      provider.normalizeEvent(Buffer.from(JSON.stringify(createTencentFunctionUrlEvent())));
+
+      const result = provider.formatResponse({
+        statusCode: 200,
+        body: 'aGVsbG8=',
+        headers: { 'content-type': 'image/png' },
+        isBase64Encoded: true,
+        multiValueHeaders: {},
+      });
+
+      expect(result.isBase64Encoded).toBeUndefined();
+      expect(result.multiValueHeaders).toBeUndefined();
+    });
+
+    it('should detect Tencent context for Function URL event', () => {
+      const rawEvent = Buffer.from(JSON.stringify(createTencentFunctionUrlEvent()));
+
+      expect(provider.detect(rawEvent, createTencentContext())).toBe(true);
     });
   });
 


### PR DESCRIPTION
Closes #19

## Summary

Support the **Tencent Cloud SCF Function URL (函数 URL)** event format for **event functions** in `TencentProvider`, alongside the legacy API Gateway trigger. Function URL events are `{ body, headers, httpMethod, path, queryString }` — they deliberately remove `requestContext`/`queryStringParameters`/`headerParameters`/`isBase64Encoded`, and query params arrive in `queryString` (previously **silently dropped**).

Web 函数 (raw HTTP on port 9000) mode needs no adapter and is out of scope.

## Changes

| Commit | Contents |
| --- | --- |
| `feat:` type + fixtures | `TencentFunctionUrlEvent` (null-tolerant optional fields), `TencentScfResponse.isBase64Encoded` → optional, `createTencentFunctionUrlEvent` fixture factory |
| `feat:` provider | Format detection via **negative exclusion** (`queryStringParameters`/`requestContext` always present on legacy, never on Function URL; `== null` tolerates tooling-injected `null`); `normalizeEvent` maps `queryString` → `queryParameters`; `formatResponse` returns exactly `{ statusCode, headers, body }` for Function URL (strips `isBase64Encoded`/`multiValueHeaders` per the documented contract); legacy API Gateway path **byte-identical** |
| `test:` e2e | Hono integration tests through the full pipeline: query echo, JSON body, custom headers, 404/500, response contract (no `isBase64Encoded`/`multiValueHeaders` keys) |
| `docs:` | Provider table + Web 函数 out-of-scope note |

## Verification

- **TDD**: RED (5 failing tests with correct assertions) → GREEN (28/28 tencent unit tests)
- **Full suite**: 31 suites, **422 tests pass**; coverage **97.01 / 88.55 / 97.05 / 97.44** (≥85 gate); `tencent.ts` **100% on all metrics**
- `npm run build` + `npm run lint:check` exit 0; pre-commit hook green
- **Manual QA** (real surface, `serverlessAdapter` + Express 5 + Hono): 11/11 — the original bug (query silently dropped) fixed; FU response keys exactly `[statusCode, headers, body]`; legacy response keeps all 5 keys

## Note for live validation

Per the issue's open questions: whether Function URL *tolerates* `isBase64Encoded`/`multiValueHeaders` in responses could not be validated without a live Tencent deployment. The strip follows the documented `{ statusCode, headers, body }` contract and the owner's verification review recommendation — worth confirming once on a real Function URL deployment before closing.

Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-openagent)

Co-authored-by: Sisyphus <clio-agent@sisyphuslabs.ai>